### PR TITLE
Adding support for min and max prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ This module extends Magento 2 Catalog GraphQl definitions.
 
 5. Fixes the Layered Navigation when filtering by category.
 
-6. Adds support for product list `min_price` and `max_price` values
-
-7. Adds `thumbnail` to `MediaGalleryEntry` type. See more in [schema.graphqls](./src/etc/schema.graphqls).
-
+6. Adds `thumbnail` to `MediaGalleryEntry` type. See more in [schema.graphqls](./src/etc/schema.graphqls).
+ 
+7.  Adds support for product list `min_price` and `max_price` values.

--- a/README.md
+++ b/README.md
@@ -24,4 +24,7 @@ This module extends Magento 2 Catalog GraphQl definitions.
 
 5. Fixes the Layered Navigation when filtering by category.
 
-6. Adds `thumbnail` to `MediaGalleryEntry` type. See more in [schema.graphqls](./src/etc/schema.graphqls).
+6. Adds support for product list `min_price` and `max_price` values
+
+7. Adds `thumbnail` to `MediaGalleryEntry` type. See more in [schema.graphqls](./src/etc/schema.graphqls).
+

--- a/src/Model/Resolver/Category/Products.php
+++ b/src/Model/Resolver/Category/Products.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Raivis Dejus <info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Category;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\GraphQl\Query\Resolver\Argument\SearchCriteria\Builder;
+use ScandiPWA\CatalogGraphQl\Model\Resolver\Products\Query\Filter;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+
+/**
+ * Category products resolver, used by GraphQL endpoints to retrieve products assigned to a category
+ */
+class Products implements ResolverInterface
+{
+    /**
+     * @var \Magento\Catalog\Api\ProductRepositoryInterface
+     */
+    private $productRepository;
+
+    /**
+     * @var Builder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @var Filter
+     */
+    private $filterQuery;
+
+    /**
+     * @param ProductRepositoryInterface $productRepository
+     * @param Builder $searchCriteriaBuilder
+     * @param Filter $filterQuery
+     */
+    public function __construct(
+        ProductRepositoryInterface $productRepository,
+        Builder $searchCriteriaBuilder,
+        Filter $filterQuery
+    ) {
+        $this->productRepository = $productRepository;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->filterQuery = $filterQuery;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        $args['filter'] = [
+            'category_id' => [
+                'eq' => $value['id']
+            ]
+        ];
+        $searchCriteria = $this->searchCriteriaBuilder->build($field->getName(), $args);
+        $searchCriteria->setCurrentPage($args['currentPage']);
+        $searchCriteria->setPageSize($args['pageSize']);
+        $searchResult = $this->filterQuery->getResult($searchCriteria, $info);
+
+        //possible division by 0
+        if ($searchCriteria->getPageSize()) {
+            $maxPages = ceil($searchResult->getTotalCount() / $searchCriteria->getPageSize());
+        } else {
+            $maxPages = 0;
+        }
+
+        $currentPage = $searchCriteria->getCurrentPage();
+        if ($searchCriteria->getCurrentPage() > $maxPages && $searchResult->getTotalCount() > 0) {
+            $currentPage = new GraphQlInputException(
+                __(
+                    'currentPage value %1 specified is greater than the number of pages available.',
+                    [$maxPages]
+                )
+            );
+        }
+
+        $data = [
+            'total_count' => $searchResult->getTotalCount(),
+            'min_price'   => $searchResult->getMinPrice(),
+            'max_price'   => $searchResult->getMaxPrice(),
+            'items'       => $searchResult->getProductsSearchResult(),
+            'page_info'   => [
+                'page_size'    => $searchCriteria->getPageSize(),
+                'current_page' => $currentPage,
+                'total_pages' => $maxPages
+            ]
+        ];
+        return $data;
+    }
+}

--- a/src/Model/Resolver/Category/Products.php
+++ b/src/Model/Resolver/Category/Products.php
@@ -75,10 +75,9 @@ class Products implements ResolverInterface
         $searchResult = $this->filterQuery->getResult($searchCriteria, $info);
 
         //possible division by 0
+        $maxPages = 0;
         if ($searchCriteria->getPageSize()) {
             $maxPages = ceil($searchResult->getTotalCount() / $searchCriteria->getPageSize());
-        } else {
-            $maxPages = 0;
         }
 
         $currentPage = $searchCriteria->getCurrentPage();

--- a/src/Model/Resolver/Products.php
+++ b/src/Model/Resolver/Products.php
@@ -24,6 +24,8 @@ use Magento\Catalog\Model\Layer\Resolver;
 /**
  * Products field resolver, used for GraphQL request processing.
  * Implementing support for min max price
+ *
+ * @SuppressWarnings(PHPMD)
  */
 class Products implements ResolverInterface
 {
@@ -91,10 +93,9 @@ class Products implements ResolverInterface
             $searchResult = $this->filterQuery->getResult($searchCriteria, $info);
         }
         //possible division by 0
+        $maxPages = 0;
         if ($searchCriteria->getPageSize()) {
             $maxPages = ceil($searchResult->getTotalCount() / $searchCriteria->getPageSize());
-        } else {
-            $maxPages = 0;
         }
 
         $currentPage = $searchCriteria->getCurrentPage();

--- a/src/Model/Resolver/Products.php
+++ b/src/Model/Resolver/Products.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Raivis Dejus <info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver;
+
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use ScandiPWA\CatalogGraphQl\Model\Resolver\Products\Query\Filter;
+use ScandiPWA\CatalogGraphQl\Model\Resolver\Products\Query\Search;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\Resolver\Argument\SearchCriteria\Builder;
+use Magento\Framework\GraphQl\Query\Resolver\Argument\SearchCriteria\SearchFilter;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Catalog\Model\Layer\Resolver;
+
+/**
+ * Products field resolver, used for GraphQL request processing.
+ * Implementing support for min max price
+ */
+class Products implements ResolverInterface
+{
+    /**
+     * @var Builder
+     */
+    private $searchCriteriaBuilder;
+
+    /**
+     * @var Search
+     */
+    private $searchQuery;
+
+    /**
+     * @var Filter
+     */
+    private $filterQuery;
+
+    /**
+     * @var SearchFilter
+     */
+    private $searchFilter;
+
+    /**
+     * @param Builder $searchCriteriaBuilder
+     * @param Search $searchQuery
+     * @param Filter $filterQuery
+     * @param SearchFilter $searchFilter
+     */
+    public function __construct(
+        Builder $searchCriteriaBuilder,
+        Search $searchQuery,
+        Filter $filterQuery,
+        SearchFilter $searchFilter
+    ) {
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->searchQuery = $searchQuery;
+        $this->filterQuery = $filterQuery;
+        $this->searchFilter = $searchFilter;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        $searchCriteria = $this->searchCriteriaBuilder->build($field->getName(), $args);
+        $searchCriteria->setCurrentPage($args['currentPage']);
+        $searchCriteria->setPageSize($args['pageSize']);
+        if (!isset($args['search']) && !isset($args['filter'])) {
+            throw new GraphQlInputException(
+                __("'search' or 'filter' input argument is required.")
+            );
+        } elseif (isset($args['search'])) {
+            $layerType = Resolver::CATALOG_LAYER_SEARCH;
+            $this->searchFilter->add($args['search'], $searchCriteria);
+            $searchResult = $this->searchQuery->getResult($searchCriteria, $info);
+        } else {
+            $layerType = Resolver::CATALOG_LAYER_CATEGORY;
+            $searchResult = $this->filterQuery->getResult($searchCriteria, $info);
+        }
+        //possible division by 0
+        if ($searchCriteria->getPageSize()) {
+            $maxPages = ceil($searchResult->getTotalCount() / $searchCriteria->getPageSize());
+        } else {
+            $maxPages = 0;
+        }
+
+        $currentPage = $searchCriteria->getCurrentPage();
+        if ($searchCriteria->getCurrentPage() > $maxPages && $searchResult->getTotalCount() > 0) {
+            throw new GraphQlInputException(
+                __(
+                    'currentPage value %1 specified is greater than the %2 page(s) available.',
+                    [$currentPage, $maxPages]
+                )
+            );
+        }
+
+
+        $data = [
+            'total_count' => $searchResult->getTotalCount(),
+            'min_price' => $searchResult->getMinPrice(),
+            'max_price' => $searchResult->getMaxPrice(),
+            'items' => $searchResult->getProductsSearchResult(),
+            'page_info' => [
+                'page_size' => $searchCriteria->getPageSize(),
+                'current_page' => $currentPage,
+                'total_pages' => $maxPages
+            ],
+            'layer_type' => $layerType
+        ];
+
+        return $data;
+    }
+}

--- a/src/Model/Resolver/Products/DataProvider/Product.php
+++ b/src/Model/Resolver/Products/DataProvider/Product.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Raivis Dejus <info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider;
+
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Catalog\Api\Data\ProductSearchResultsInterfaceFactory;
+use Magento\Framework\Api\SearchResultsInterface;
+use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessorInterface;
+
+/**
+ * Product field data provider, used for GraphQL resolver processing.
+ * Adds support for price min and max values
+ */
+class Product extends \Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product
+{
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
+
+    /**
+     * @var ProductSearchResultsInterfaceFactory
+     */
+    private $searchResultsFactory;
+
+    /**
+     * @var CollectionProcessorInterface
+     */
+    private $collectionProcessor;
+
+    /**
+     * @var Visibility
+     */
+    private $visibility;
+
+    /**
+     * @var float
+     */
+    private $minPrice;
+
+    /**
+     * @var float
+     */
+    private $maxPrice;
+
+    /**
+     * @param CollectionFactory $collectionFactory
+     * @param ProductSearchResultsInterfaceFactory $searchResultsFactory
+     * @param Visibility $visibility
+     * @param CollectionProcessorInterface $collectionProcessor
+     */
+    public function __construct(
+        CollectionFactory $collectionFactory,
+        ProductSearchResultsInterfaceFactory $searchResultsFactory,
+        Visibility $visibility,
+        CollectionProcessorInterface $collectionProcessor
+    ) {
+        $this->collectionFactory = $collectionFactory;
+        $this->searchResultsFactory = $searchResultsFactory;
+        $this->visibility = $visibility;
+        $this->collectionProcessor = $collectionProcessor;
+    }
+
+    /**
+     * Gets list of product data with full data set. Adds eav attributes to result set from passed in array
+     *
+     * @param SearchCriteriaInterface $searchCriteria
+     * @param string[] $attributes
+     * @param bool $isSearch
+     * @param bool $isChildSearch
+     * @return SearchResultsInterface
+     */
+    public function getList(
+        SearchCriteriaInterface $searchCriteria,
+        array $attributes = [],
+        bool $isSearch = false,
+        bool $isChildSearch = false
+    ): SearchResultsInterface {
+        /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $collection */
+        $collection = $this->collectionFactory->create();
+
+        $this->collectionProcessor->process($collection, $searchCriteria, $attributes);
+
+        if (!$isChildSearch) {
+            $visibilityIds = $isSearch
+                ? $this->visibility->getVisibleInSearchIds()
+                : $this->visibility->getVisibleInCatalogIds();
+            $collection->setVisibility($visibilityIds);
+        }
+
+        $collection->load();
+
+        // Methods that perform extra fetches post-load
+        if (in_array('media_gallery_entries', $attributes)) {
+            $collection->addMediaGalleryData();
+        }
+        if (in_array('options', $attributes)) {
+            $collection->addOptionsToResult();
+        }
+
+        $searchResult = $this->searchResultsFactory->create();
+        $searchResult->setSearchCriteria($searchCriteria);
+        $searchResult->setItems($collection->getItems());
+        $searchResult->setTotalCount($collection->getSize());
+
+        list($this->minPrice,$this->maxPrice) = $this->getCollectionMinMaxPrice($collection);
+        return $searchResult;
+    }
+
+
+    /**
+     * @param \Magento\Catalog\Model\ResourceModel\Product\Collection $collection
+     * @return array
+     */
+    public function getCollectionMinMaxPrice($collection)
+    {
+        $connection = $collection->getConnection();
+        $entityIds = $collection->getAllIds();
+
+        $row = $connection->fetchRow('SELECT MIN(min_price) as min_price, MAX(max_price) as max_price FROM catalog_product_index_price WHERE entity_id IN(\'' . \implode("','", $entityIds) . '\')');
+
+        return [floatval($row['min_price']),floatval($row['max_price'])];
+    }
+
+    /**
+     * @return float
+     */
+    public function getMinPrice()
+    {
+        return $this->minPrice;
+    }
+
+    /**
+     * @return float
+     */
+    public function getMaxPrice()
+    {
+        return $this->maxPrice;
+    }
+}

--- a/src/Model/Resolver/Products/Query/Filter.php
+++ b/src/Model/Resolver/Products/Query/Filter.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Raivis Dejus <info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Products\Query;
+
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product;
+use ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchResult;
+use ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchResultFactory;
+use Magento\Framework\GraphQl\Query\FieldTranslator;
+
+/**
+ * Retrieve filtered product data based off given search criteria in a format that GraphQL can interpret.
+ * Adds support for min and manx price values
+ */
+class Filter
+{
+    /**
+     * @var SearchResultFactory
+     */
+    private $searchResultFactory;
+
+    /**
+     * @var \ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product
+     */
+    private $productDataProvider;
+
+    /**
+     * @var FieldTranslator
+     */
+    private $fieldTranslator;
+
+    /**
+     * @var \Magento\Catalog\Model\Layer\Resolver
+     */
+    private $layerResolver;
+
+    /**
+     * @param SearchResultFactory $searchResultFactory
+     * @param Product $productDataProvider
+     * @param \Magento\Catalog\Model\Layer\Resolver $layerResolver
+     * @param FieldTranslator $fieldTranslator
+     */
+    public function __construct(
+        SearchResultFactory $searchResultFactory,
+        Product $productDataProvider,
+        \Magento\Catalog\Model\Layer\Resolver $layerResolver,
+        FieldTranslator $fieldTranslator
+    ) {
+        $this->searchResultFactory = $searchResultFactory;
+        $this->productDataProvider = $productDataProvider;
+        $this->fieldTranslator = $fieldTranslator;
+        $this->layerResolver = $layerResolver;
+    }
+
+    /**
+     * Filter catalog product data based off given search criteria
+     *
+     * @param SearchCriteriaInterface $searchCriteria
+     * @param ResolveInfo $info
+     * @param bool $isSearch
+     * @return SearchResult
+     */
+    public function getResult(
+        SearchCriteriaInterface $searchCriteria,
+        ResolveInfo $info,
+        bool $isSearch = false
+    ): SearchResult {
+        $fields = $this->getProductFields($info);
+        $products = $this->productDataProvider->getList($searchCriteria, $fields, $isSearch);
+        $productArray = [];
+        /** @var \Magento\Catalog\Model\Product $product */
+        foreach ($products->getItems() as $product) {
+            $productArray[$product->getId()] = $product->getData();
+            $productArray[$product->getId()]['model'] = $product;
+        }
+
+        return $this->searchResultFactory->create(
+            $products->getTotalCount(),
+            $this->productDataProvider->getMinPrice(),
+            $this->productDataProvider->getMaxPrice(),
+            $productArray
+        );
+    }
+
+    /**
+     * Return field names for all requested product fields.
+     *
+     * @param ResolveInfo $info
+     * @return string[]
+     */
+    private function getProductFields(ResolveInfo $info) : array
+    {
+        $fieldNames = [];
+        foreach ($info->fieldNodes as $node) {
+            if ($node->name->value !== 'products') {
+                continue;
+            }
+            foreach ($node->selectionSet->selections as $selection) {
+                if ($selection->name->value !== 'items') {
+                    continue;
+                }
+
+                foreach ($selection->selectionSet->selections as $itemSelection) {
+                    if ($itemSelection->kind === 'InlineFragment') {
+                        foreach ($itemSelection->selectionSet->selections as $inlineSelection) {
+                            if ($inlineSelection->kind === 'InlineFragment') {
+                                continue;
+                            }
+                            $fieldNames[] = $this->fieldTranslator->translate($inlineSelection->name->value);
+                        }
+                        continue;
+                    }
+                    $fieldNames[] = $this->fieldTranslator->translate($itemSelection->name->value);
+                }
+            }
+        }
+
+        return $fieldNames;
+    }
+}

--- a/src/Model/Resolver/Products/Query/Search.php
+++ b/src/Model/Resolver/Products/Query/Search.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Raivis Dejus <info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Products\Query;
+
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\Api\Search\SearchCriteriaInterface;
+use Magento\CatalogGraphQl\Model\Resolver\Products\SearchCriteria\Helper\Filter as FilterHelper;
+use ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchResult;
+use ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchResultFactory;
+use Magento\Search\Api\SearchInterface;
+
+/**
+ * Full text search for catalog using given search criteria.
+ * Adds support for min and manx price values
+ */
+class Search
+{
+    /**
+     * @var SearchInterface
+     */
+    private $search;
+
+    /**
+     * @var FilterHelper
+     */
+    private $filterHelper;
+
+    /**
+     * @var Filter
+     */
+    private $filterQuery;
+
+    /**
+     * @var SearchResultFactory
+     */
+    private $searchResultFactory;
+
+    /**
+     * @var \Magento\Framework\EntityManager\MetadataPool
+     */
+    private $metadataPool;
+
+    /**
+     * @var \Magento\Search\Model\Search\PageSizeProvider
+     */
+    private $pageSizeProvider;
+
+    /**
+     * @param SearchInterface $search
+     * @param FilterHelper $filterHelper
+     * @param Filter $filterQuery
+     * @param SearchResultFactory $searchResultFactory
+     * @param \Magento\Framework\EntityManager\MetadataPool $metadataPool
+     * @param \Magento\Search\Model\Search\PageSizeProvider $pageSize
+     */
+    public function __construct(
+        SearchInterface $search,
+        FilterHelper $filterHelper,
+        Filter $filterQuery,
+        SearchResultFactory $searchResultFactory,
+        \Magento\Framework\EntityManager\MetadataPool $metadataPool,
+        \Magento\Search\Model\Search\PageSizeProvider $pageSize
+    ) {
+        $this->search = $search;
+        $this->filterHelper = $filterHelper;
+        $this->filterQuery = $filterQuery;
+        $this->searchResultFactory = $searchResultFactory;
+        $this->metadataPool = $metadataPool;
+        $this->pageSizeProvider = $pageSize;
+    }
+
+    /**
+     * Return results of full text catalog search of given term, and will return filtered results if filter is specified
+     *
+     * @param SearchCriteriaInterface $searchCriteria
+     * @param ResolveInfo $info
+     * @return SearchResult
+     * @throws \Exception
+     */
+    public function getResult(SearchCriteriaInterface $searchCriteria, ResolveInfo $info) : SearchResult
+    {
+        $idField = $this->metadataPool->getMetadata(
+            \Magento\Catalog\Api\Data\ProductInterface::class
+        )->getIdentifierField();
+        $realPageSize = $searchCriteria->getPageSize();
+        $realCurrentPage = $searchCriteria->getCurrentPage();
+        // Current page must be set to 0 and page size to max for search to grab all ID's as temporary workaround
+        $pageSize = $this->pageSizeProvider->getMaxPageSize();
+        $searchCriteria->setPageSize($pageSize);
+        $searchCriteria->setCurrentPage(0);
+        $itemsResults = $this->search->search($searchCriteria);
+
+        $ids = [];
+        $searchIds = [];
+        foreach ($itemsResults->getItems() as $item) {
+            $ids[$item->getId()] = null;
+            $searchIds[] = $item->getId();
+        }
+
+        $filter = $this->filterHelper->generate($idField, 'in', $searchIds);
+        $searchCriteria = $this->filterHelper->remove($searchCriteria, 'search_term');
+        $searchCriteria = $this->filterHelper->add($searchCriteria, $filter);
+        $searchResult = $this->filterQuery->getResult($searchCriteria, $info, true);
+
+        $searchCriteria->setPageSize($realPageSize);
+        $searchCriteria->setCurrentPage($realCurrentPage);
+        $paginatedProducts = $this->paginateList($searchResult, $searchCriteria);
+
+        $products = [];
+        if (!isset($searchCriteria->getSortOrders()[0])) {
+            foreach ($paginatedProducts as $product) {
+                if (in_array($product[$idField], $searchIds)) {
+                    $ids[$product[$idField]] = $product;
+                }
+            }
+            $products = array_filter($ids);
+        } else {
+            foreach ($paginatedProducts as $product) {
+                $productId = isset($product['entity_id']) ? $product['entity_id'] : $product[$idField];
+                if (in_array($productId, $searchIds)) {
+                    $products[] = $product;
+                }
+            }
+        }
+
+        return $this->searchResultFactory->create(
+            $searchResult->getTotalCount(),
+            $searchResult->getMinPrice(),
+            $searchResult->getMaxPrice(),
+            $products
+        );
+    }
+
+
+    /**
+     * Paginate an array of Ids that get pulled back in search based off search criteria and total count.
+     *
+     * @param SearchResult $searchResult
+     * @param SearchCriteriaInterface $searchCriteria
+     * @return int[]
+     */
+    private function paginateList(SearchResult $searchResult, SearchCriteriaInterface $searchCriteria) : array
+    {
+        $length = $searchCriteria->getPageSize();
+        // Search starts pages from 0
+        $offset = $length * ($searchCriteria->getCurrentPage() - 1);
+
+        if ($searchCriteria->getPageSize()) {
+            $maxPages = ceil($searchResult->getTotalCount() / $searchCriteria->getPageSize()) - 1;
+        } else {
+            $maxPages = 0;
+        }
+
+        if ($searchCriteria->getCurrentPage() > $maxPages && $searchResult->getTotalCount() > 0) {
+            $offset = (int)$maxPages;
+        }
+        return array_slice($searchResult->getProductsSearchResult(), $offset, $length);
+    }
+}

--- a/src/Model/Resolver/Products/Query/Search.php
+++ b/src/Model/Resolver/Products/Query/Search.php
@@ -123,12 +123,19 @@ class Search
                 }
             }
             $products = array_filter($ids);
-        } else {
-            foreach ($paginatedProducts as $product) {
-                $productId = isset($product['entity_id']) ? $product['entity_id'] : $product[$idField];
-                if (in_array($productId, $searchIds)) {
-                    $products[] = $product;
-                }
+
+            return $this->searchResultFactory->create(
+                $searchResult->getTotalCount(),
+                $searchResult->getMinPrice(),
+                $searchResult->getMaxPrice(),
+                $products
+            );
+        }
+
+        foreach ($paginatedProducts as $product) {
+            $productId = isset($product['entity_id']) ? $product['entity_id'] : $product[$idField];
+            if (in_array($productId, $searchIds)) {
+                $products[] = $product;
             }
         }
 
@@ -154,10 +161,9 @@ class Search
         // Search starts pages from 0
         $offset = $length * ($searchCriteria->getCurrentPage() - 1);
 
+        $maxPages = 0;
         if ($searchCriteria->getPageSize()) {
             $maxPages = ceil($searchResult->getTotalCount() / $searchCriteria->getPageSize()) - 1;
-        } else {
-            $maxPages = 0;
         }
 
         if ($searchCriteria->getCurrentPage() > $maxPages && $searchResult->getTotalCount() > 0) {

--- a/src/Model/Resolver/Products/SearchResult.php
+++ b/src/Model/Resolver/Products/SearchResult.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Raivis Dejus <info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Products;
+
+use phpDocumentor\Reflection\Types\Float_;
+
+/**
+ * Container for a product search holding the item result and the array in the GraphQL-readable product type format.
+ * This class adds support for min and max price
+ */
+class SearchResult
+{
+    /**
+     * @var int
+     */
+    private $totalCount;
+
+    /**
+     * @var float
+     */
+    private $minPrice;
+
+    /**
+     * @var float
+     */
+    private $maxPrice;
+
+    /**
+     * @var array
+     */
+    private $productsSearchResult;
+
+    /**
+     * @param int $totalCount
+     * @param float $minPrice
+     * @param float $maxPrice
+     * @param array $productsSearchResult
+     */
+    public function __construct(
+        int $totalCount,
+        float $minPrice,
+        float $maxPrice,
+        array $productsSearchResult
+    ) {
+        $this->totalCount = $totalCount;
+        $this->minPrice = $minPrice;
+        $this->maxPrice = $maxPrice;
+        $this->productsSearchResult = $productsSearchResult;
+    }
+
+    /**
+     * Return total count of search and filtered result
+     *
+     * @return int
+     */
+    public function getTotalCount() : int
+    {
+        return $this->totalCount;
+    }
+
+    /**
+     * Return min price of search and filtered result
+     *
+     * @return float
+     */
+    public function getMinPrice() : float
+    {
+        return $this->minPrice;
+    }
+
+    /**
+     * Return max price of search and filtered result
+     *
+     * @return float
+     */
+    public function getMaxPrice() : float
+    {
+        return $this->maxPrice;
+    }
+
+    /**
+     * Retrieve an array in the format of GraphQL-readable type containing product data.
+     *
+     * @return array
+     */
+    public function getProductsSearchResult() : array
+    {
+        return $this->productsSearchResult;
+    }
+}

--- a/src/Model/Resolver/Products/SearchResultFactory.php
+++ b/src/Model/Resolver/Products/SearchResultFactory.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Raivis Dejus <info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Products;
+
+use Magento\Framework\ObjectManagerInterface;
+
+/**
+ * Generate SearchResult based off of total count from query and array of products and their data.
+ * This class adds support for min and max price
+ */
+class SearchResultFactory
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $objectManager;
+
+    /**
+     * @param ObjectManagerInterface $objectManager
+     */
+    public function __construct(ObjectManagerInterface $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * Instantiate SearchResult
+     *
+     * @param int $totalCount
+     * @param float $minPrice
+     * @param float $maxPrice
+     * @param array $productsSearchResult
+     * @return SearchResult
+     */
+    public function create(
+        int $totalCount,
+        float $minPrice,
+        float $maxPrice,
+        array $productsSearchResult
+    ) : SearchResult
+    {
+        return $this->objectManager->create(
+            SearchResult::class,
+            [
+                'totalCount' => $totalCount,
+                'minPrice' => $minPrice,
+                'maxPrice' => $maxPrice,
+                'productsSearchResult' => $productsSearchResult
+            ]
+        );
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -34,4 +34,32 @@
 
     <preference for="Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\CategoryTree"
                 type="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\CategoryTree"/>
+
+    <preference for="Magento\CatalogGraphQl\Model\Resolver\Products\SearchResult"
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchResult"/>
+
+    <preference for="Magento\CatalogGraphQl\Model\Resolver\Products\SearchResultFactory"
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchResultFactory"/>
+
+    <preference for="Magento\CatalogGraphQl\Model\Resolver\Products"
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Products"/>
+
+    <preference for="Magento\CatalogGraphQl\Model\Resolver\Category\Products"
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Category\Products"/>
+
+    <preference for="Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product"
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product"/>
+
+    <preference for="Magento\CatalogGraphQl\Model\Resolver\Products\Query\Filter"
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\Query\Filter"/>
+
+    <preference for="Magento\CatalogGraphQl\Model\Resolver\Products\Query\Search"
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\Query\Search"/>
+
+    <type name="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\Query\Search">
+        <arguments>
+            <argument name="pageSize" xsi:type="object">ScandiPWA\CatalogGraphQl\Model\Search\PageSizeProvider</argument>
+        </arguments>
+    </type>
+
 </config>

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -5,6 +5,7 @@
 # @package     ScandiPWA_CatalogGraphQl
 # @author      Viktors Pliska <info@scandiweb.com>
 # @author      Valerijs Sceglovs <info@scandiweb.com>
+# @author      Raivis Dejus <info@scandiweb.com>
 # @copyright   Copyright (c) 2018 Scandiweb, Ltd (https://scandiweb.com)
 ##
 
@@ -62,4 +63,14 @@ type AttributeWithValueOption {
 type AttributeWithValueSwatchData {
     type: String
     value: String
+}
+
+type Products {
+    min_price: Float @doc(description: "Minimal price among all selected items")
+    max_price: Float @doc(description: "Maximal price among all selected items")
+}
+
+type CategoryProducts {
+    min_price: Float @doc(description: "Minimal price among all selected items")
+    max_price: Float @doc(description: "Maximal price among all selected items")
 }


### PR DESCRIPTION
`Model/Resolver/Products/DataProvider/Product.php ` Will get all the ID's from current collection and will look for min and max price in `catalog_product_index_price`.

The rest of the files are used for overrides to pass the min and max values to the resolvers