### PR TITLE
Fixed filter items count in layered navigation

### DIFF
--- a/src/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor/ConfigurableProductAttributeFilter.php
+++ b/src/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor/ConfigurableProductAttributeFilter.php
@@ -46,6 +46,8 @@ class ConfigurableProductAttributeFilter implements CustomFilterInterface
         $attributeValue = $filter->getValue();
         $category = $this->registry->registry('current_category');
 
+        $this->_saveActiveFiltersToRegistry($attributeName, $attributeValue);
+
         $simpleSelect = $this->collectionFactory->create()
             ->addAttributeToFilter($attributeName, [$conditionType => $attributeValue])
             ->addAttributeToFilter('status', Status::STATUS_ENABLED);
@@ -85,5 +87,20 @@ class ConfigurableProductAttributeFilter implements CustomFilterInterface
             ));
 
         return true;
+    }
+
+    /**
+     * Save active filters to registry
+     *
+     * @param $attributeName
+     * @param $attributeValues
+     */
+    protected function _saveActiveFiltersToRegistry($attributeName, $attributeValues)
+    {
+        $registry = $this->registry->registry('filter_attributes') ?? [];
+        $registry[$attributeName] = $attributeValues;
+
+        $this->registry->unregister('filter_attributes');
+        $this->registry->register('filter_attributes', $registry);
     }
 }

--- a/src/Model/ResourceModel/Layer/Filter/Attribute.php
+++ b/src/Model/ResourceModel/Layer/Filter/Attribute.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Kirils Scerba <kirill@scandiweb.com | info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
+ */
+
+namespace ScandiPWA\CatalogGraphQl\Model\ResourceModel\Layer\Filter;
+
+use Magento\Framework\Registry;
+use Magento\Framework\Model\ResourceModel\Db\Context;
+use Magento\Catalog\Model\Layer\Filter\FilterInterface;
+
+/**
+ * Class Attribute
+ * @package ScandiPWA\CatalogGraphQl\Model\ResourceModel\Layer\Filter
+ */
+class Attribute extends \Magento\Catalog\Model\ResourceModel\Layer\Filter\Attribute
+{
+    /**
+     * @var Registry
+     */
+    protected $registry;
+
+    /**
+     * @param Registry $registry
+     * @param Context $context
+     * @param null $connectionName
+     */
+    public function __construct(
+        Registry $registry,
+        Context $context,
+        $connectionName = null
+    )
+    {
+        $this->registry = $registry;
+        parent::__construct($context, $connectionName);
+    }
+
+    /**
+     * Retrieve array with products counts per attribute option
+     *
+     * @param FilterInterface $filter
+     * @return array
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getCount(FilterInterface $filter)
+    {
+        // clone select from collection with filters
+        $select = clone $filter->getLayer()->getProductCollection()->getSelect();
+
+        // reset columns, order and limitation conditions
+        $select->reset(\Magento\Framework\DB\Select::COLUMNS);
+        $select->reset(\Magento\Framework\DB\Select::ORDER);
+        $select->reset(\Magento\Framework\DB\Select::LIMIT_COUNT);
+        $select->reset(\Magento\Framework\DB\Select::LIMIT_OFFSET);
+
+        $connection = $this->getConnection();
+        $attribute = $filter->getAttributeModel();
+        $attributeTableAlias = sprintf('%s_idx', $attribute->getAttributeCode());
+        $categoryTableAlias = 'category_product';
+        $category = $this->registry->registry('current_category');
+
+        // join category
+        $categoryQueryConditions = [
+            "{$categoryTableAlias}.product_id = e.entity_id",
+            "{$categoryTableAlias}.category_id = {$category->getId()}"
+        ];
+        $select->join(
+            [$categoryTableAlias => $this->getTable('catalog_category_product')],
+            join(' AND ', $categoryQueryConditions),
+            null
+        );
+
+        // join attribute
+        $attributeQueryConditions = [
+            "{$attributeTableAlias}.entity_id = e.entity_id",
+            $connection->quoteInto("{$attributeTableAlias}.attribute_id = ?", $attribute->getAttributeId()),
+            $connection->quoteInto("{$attributeTableAlias}.store_id = ?", $filter->getStoreId()),
+        ];
+        $select->join(
+            [$attributeTableAlias => $this->getMainTable()],
+            join(' AND ', $attributeQueryConditions),
+            ['value', 'count' => new \Zend_Db_Expr("COUNT({$attributeTableAlias}.entity_id)")]
+        );
+
+        $select->group(
+            ["{$attributeTableAlias}.value", "{$categoryTableAlias}.category_id"]
+        );
+
+        return $connection->fetchPairs($select);
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -83,6 +83,9 @@
     <preference for="Magento\CatalogWidget\Model\Rule\Condition\Product"
                 type="ScandiPWA\CatalogGraphQl\Model\Rule\Condition\Product" />
 
+    <preference for="Magento\Catalog\Model\ResourceModel\Layer\Filter\Attribute"
+                type="ScandiPWA\CatalogGraphQl\Model\ResourceModel\Layer\Filter\Attribute" />
+
     <type name="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\Query\Search">
         <arguments>
             <argument name="pageSize" xsi:type="object">ScandiPWA\CatalogGraphQl\Model\Search\PageSizeProvider</argument>


### PR DESCRIPTION
The default Magento layered navigation functionality does not take into account the current product category when getting the number of products for each filter item, which causes the inappropriate filters to be shown in the catalog.