### PR TITLE
Hide empty filters

### DIFF
--- a/src/Model/Resolver/Layer/DataProvider/Filters.php
+++ b/src/Model/Resolver/Layer/DataProvider/Filters.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Artjoms Travkovs <info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare (strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Layer\DataProvider;
+
+use Magento\CatalogGraphQl\Model\Resolver\Layer\FiltersProvider;
+use Magento\Catalog\Model\Layer\Filter\AbstractFilter;
+
+/**
+ * Layered navigation filters data provider.
+ */
+class Filters extends \Magento\CatalogGraphQl\Model\Resolver\Layer\DataProvider\Filters
+{
+    /**
+     * @var FiltersProvider
+     */
+    private $filtersProvider;
+
+    /**
+     * @var array
+     */
+    private $requiredAttributes = [];
+
+    /**
+     * Filters constructor.
+     * @param FiltersProvider $filtersProvider
+     */
+    public function __construct(
+        FiltersProvider $filtersProvider
+    ) {
+        $this->filtersProvider = $filtersProvider;
+    }
+
+    /**
+     * Sets attributes that are being used by products
+     *
+     * @param array $items
+     * @return void
+     */
+    public function setRequiredAttributesFromItems(array $items)
+    {
+        $attributes = [];
+
+        foreach ($items as $item) {
+            $model = $item['model'];
+            $itemAttributes = $model->getAttributes();
+
+            $itemAttributeCodes = [];
+            foreach ($itemAttributes as $attribute) {
+                $itemAttributeCodes[] = $attribute->getAttributeCode();
+            }
+
+            $attributes = array_unique(array_merge($attributes, $itemAttributeCodes));
+        }
+
+        $this->requiredAttributes = $attributes;
+    }
+
+    /**
+     * Get layered navigation filters data
+     *
+     * @param string $layerType
+     * @return array
+     */
+    public function getData(string $layerType): array
+    {
+        $filtersData = [];
+        /** @var AbstractFilter $filter */
+        foreach ($this->filtersProvider->getFilters($layerType) as $filter) {
+            if ($filter->getItemsCount() && $this->hasFilterContents($filter)) {
+                $filterGroup = [
+                    'name' => (string) $filter->getName(),
+                    'filter_items_count' => $filter->getItemsCount(),
+                    'request_var' => $filter->getRequestVar(),
+                ];
+                /** @var \Magento\Catalog\Model\Layer\Filter\Item $filterItem */
+                foreach ($filter->getItems() as $filterItem) {
+                    $filterGroup['filter_items'][] = [
+                        'label' => (string) $filterItem->getLabel(),
+                        'value_string' => $filterItem->getValueString(),
+                        'items_count' => $filterItem->getCount(),
+                    ];
+                }
+                $filtersData[] = $filterGroup;
+            }
+        }
+
+        return $filtersData;
+    }
+
+    /**
+     * Checks whether filter attribute is present in products
+     *
+     * @param AbstractFilter $filter
+     * @return boolean
+     */
+    protected function hasFilterContents(AbstractFilter $filter)
+    {
+        if (!$this->requiredAttributes) {
+            return true;
+        }
+
+        return in_array($filter->getRequestVar(), $this->requiredAttributes);
+    }
+}

--- a/src/Model/Resolver/Layer/DataProvider/Filters.php
+++ b/src/Model/Resolver/Layer/DataProvider/Filters.php
@@ -51,11 +51,12 @@ class Filters extends \Magento\CatalogGraphQl\Model\Resolver\Layer\DataProvider\
 
         foreach ($items as $item) {
             $model = $item['model'];
-            $itemAttributes = $model->getAttributes();
 
             $itemAttributeCodes = [];
-            foreach ($itemAttributes as $attribute) {
-                $itemAttributeCodes[] = $attribute->getAttributeCode();
+            foreach ($model->getAttributes() as $attribute) {
+                if ($attribute->getIsVisibleOnFront()) {
+                    $itemAttributeCodes[] = $attribute->getAttributeCode();
+                }
             }
 
             $attributes = array_unique(array_merge($attributes, $itemAttributeCodes));

--- a/src/Model/Resolver/Layer/DataProvider/Filters.php
+++ b/src/Model/Resolver/Layer/DataProvider/Filters.php
@@ -54,7 +54,7 @@ class Filters extends \Magento\CatalogGraphQl\Model\Resolver\Layer\DataProvider\
 
             $itemAttributeCodes = [];
             foreach ($model->getAttributes() as $attribute) {
-                if ($attribute->getIsVisibleOnFront()) {
+                if ($attribute->getIsFilterable()) {
                     $itemAttributeCodes[] = $attribute->getAttributeCode();
                 }
             }

--- a/src/Model/Resolver/Layer/DataProvider/Filters.php
+++ b/src/Model/Resolver/Layer/DataProvider/Filters.php
@@ -104,7 +104,7 @@ class Filters extends \Magento\CatalogGraphQl\Model\Resolver\Layer\DataProvider\
      */
     protected function hasFilterContents(AbstractFilter $filter)
     {
-        if (!$this->requiredAttributes) {
+        if (count($this->requiredAttributes) <= 0) {
             return true;
         }
 

--- a/src/Model/Resolver/LayerFilters.php
+++ b/src/Model/Resolver/LayerFilters.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Artjoms Travkovs <info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare (strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+
+/**
+ * Layered navigation filters resolver, used for GraphQL request processing.
+ */
+class LayerFilters implements ResolverInterface
+{
+    /**
+     * @var Layer\DataProvider\Filters
+     */
+    private $filtersDataProvider;
+
+    /**
+     * @param \ScandiPWA\CatalogGraphQl\Model\Resolver\Layer\DataProvider\Filters $filtersDataProvider
+     */
+    public function __construct(
+        \ScandiPWA\CatalogGraphQl\Model\Resolver\Layer\DataProvider\Filters $filtersDataProvider
+    ) {
+        $this->filtersDataProvider = $filtersDataProvider;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['layer_type'])) {
+            return null;
+        }
+
+        $this->filtersDataProvider->setRequiredAttributesFromItems($value['items'] ?? []);
+
+        return $this->filtersDataProvider->getData($value['layer_type']);
+    }
+}

--- a/src/Model/Resolver/LayerFilters.php
+++ b/src/Model/Resolver/LayerFilters.php
@@ -18,7 +18,7 @@ use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 /**
  * Layered navigation filters resolver, used for GraphQL request processing.
  */
-class LayerFilters implements ResolverInterface
+class LayerFilters extends \Magento\CatalogGraphQl\Model\Resolver\LayerFilters implements ResolverInterface
 {
     /**
      * @var Layer\DataProvider\Filters

--- a/src/Model/Resolver/Products.php
+++ b/src/Model/Resolver/Products.php
@@ -108,30 +108,6 @@ class Products implements ResolverInterface
             );
         }
 
-        // $items = $searchResult->getProductsSearchResult();
-
-        // echo $searchResult->getTotalCount();
-        // exit;
-
-        // $attributes = [];
-
-        // foreach ($items as $item) {
-        //     $model = $item['model'];
-        //     $itemAttributes = $model->getAttributes();
-
-        //     $itemAttributeCodes = [];
-        //     foreach ($itemAttributes as $attribute) {
-        //         echo $model->getName() . ': ' . $attribute->getAttributeCode() . PHP_EOL;
-        //         $itemAttributeCodes[] = $attribute->getAttributeCode();
-        //     }
-
-        //     $attributes = array_unique(array_merge($attributes, $itemAttributeCodes));
-        // }
-
-        // exit;
-        // print_r($attributes);
-
-
         $data = [
             'total_count' => $searchResult->getTotalCount(),
             'min_price' => $searchResult->getMinPrice(),

--- a/src/Model/Resolver/Products.php
+++ b/src/Model/Resolver/Products.php
@@ -108,6 +108,29 @@ class Products implements ResolverInterface
             );
         }
 
+        // $items = $searchResult->getProductsSearchResult();
+
+        // echo $searchResult->getTotalCount();
+        // exit;
+
+        // $attributes = [];
+
+        // foreach ($items as $item) {
+        //     $model = $item['model'];
+        //     $itemAttributes = $model->getAttributes();
+
+        //     $itemAttributeCodes = [];
+        //     foreach ($itemAttributes as $attribute) {
+        //         echo $model->getName() . ': ' . $attribute->getAttributeCode() . PHP_EOL;
+        //         $itemAttributeCodes[] = $attribute->getAttributeCode();
+        //     }
+
+        //     $attributes = array_unique(array_merge($attributes, $itemAttributeCodes));
+        // }
+
+        // exit;
+        // print_r($attributes);
+
 
         $data = [
             'total_count' => $searchResult->getTotalCount(),

--- a/src/Model/Resolver/Products.php
+++ b/src/Model/Resolver/Products.php
@@ -108,6 +108,7 @@ class Products implements ResolverInterface
             );
         }
 
+
         $data = [
             'total_count' => $searchResult->getTotalCount(),
             'min_price' => $searchResult->getMinPrice(),

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -83,6 +83,12 @@
     <preference for="Magento\CatalogWidget\Model\Rule\Condition\Product"
                 type="ScandiPWA\CatalogGraphQl\Model\Rule\Condition\Product" />
 
+    <preference for="Magento\CatalogGraphQl\Model\Resolver\Layer\DataProvider\Filters"
+            type="ScandiPWA\CatalogGraphQl\Model\Resolver\Layer\DataProvider\Filters" />
+
+    <preference for="Magento\CatalogGraphQl\Model\Resolver\LayerFilters"
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\LayerFilters" />
+
     <type name="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\Query\Search">
         <arguments>
             <argument name="pageSize" xsi:type="object">ScandiPWA\CatalogGraphQl\Model\Search\PageSizeProvider</argument>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -83,9 +83,6 @@
     <preference for="Magento\CatalogWidget\Model\Rule\Condition\Product"
                 type="ScandiPWA\CatalogGraphQl\Model\Rule\Condition\Product" />
 
-    <preference for="Magento\CatalogGraphQl\Model\Resolver\Layer\DataProvider\Filters"
-            type="ScandiPWA\CatalogGraphQl\Model\Resolver\Layer\DataProvider\Filters" />
-
     <preference for="Magento\CatalogGraphQl\Model\Resolver\LayerFilters"
                 type="ScandiPWA\CatalogGraphQl\Model\Resolver\LayerFilters" />
 


### PR DESCRIPTION
Re-implemented solution, to hide only whole filter blocks, but not distinct filters (i.e. to hide all "Size" filters, but not to hide "Red" in colors while other colors are present).