### PR TITLE
Stop loading products all over again each time we request attributes.

### DIFF
--- a/src/Model/Resolver/AttributesWithValue.php
+++ b/src/Model/Resolver/AttributesWithValue.php
@@ -62,7 +62,7 @@ class AttributesWithValue implements ResolverInterface
     /**
      * Fetches the data from persistence models and format it according to the GraphQL schema.
      *
-     * @param \Magento\Framework\GraphQl\Config\Element\Field $field
+     * @param Field $field
      * @param ContextInterface $context
      * @param ResolveInfo $info
      * @param array|null $value

--- a/src/Model/Resolver/AttributesWithValue.php
+++ b/src/Model/Resolver/AttributesWithValue.php
@@ -47,6 +47,18 @@ class AttributesWithValue implements ResolverInterface
         $this->productRepository = $productRepository;
     }
 
+    protected function getAttributeOptions($attr, $rawOptions) {
+        if (!$this->swatchHelper->isSwatchAttribute($attr)) return [];
+
+        $optionIds = array_map(function ($option) { return $option['value']; }, $rawOptions);
+        $swatchOptions = $this->swatchHelper->getSwatchesByOptionsId($optionIds);
+
+        return array_map(function ($option) use ($swatchOptions) {
+            $option['swatch_data'] = $swatchOptions[$option['value']] ?? [];
+            return $option;
+        }, $rawOptions);
+    }
+
     /**
      * Fetches the data from persistence models and format it according to the GraphQL schema.
      *
@@ -65,30 +77,21 @@ class AttributesWithValue implements ResolverInterface
         array $value = null,
         array $args = null
     ) {
-        $product = $this->productRepository->getById($value['entity_id']);
-        $attributes = $product->getAttributes();
+        $product = $value['model'];
         $attributesToReturn = [];
 
-        foreach ($attributes as $attribute) {
-            if ($attribute->getIsVisibleOnFront()) {
-                $productAttribute = $product->getCustomAttribute($attribute->getAttributeCode());
-
-                $rawOptions = $attribute->getSource()->getAllOptions(true, true);
+        foreach ($product->getAttributes() as $attr) {
+            if ($attr->getIsVisibleOnFront()) {
+                $rawOptions = $attr->getSource()->getAllOptions(true, true);
                 array_shift($rawOptions);
 
-                $optionIds = array_map(function ($option) { return $option['value']; }, $rawOptions);
-                $swatchOptions = $this->swatchHelper->getSwatchesByOptionsId($optionIds);
-
                 $attributesToReturn[] = [
-                    'attribute_value' => $productAttribute ? $productAttribute->getValue() : null,
-                    'attribute_code' => $attribute->getAttributeCode(),
-                    'attribute_type' => $attribute->getFrontendInput(),
-                    'attribute_label' => $attribute->getFrontendLabel(),
-                    'attribute_id' => $attribute->getAttributeId(),
-                    'attribute_options' => array_map(function ($option) use ($swatchOptions) {
-                        $option['swatch_data'] = $swatchOptions[$option['value']] ?? [];
-                        return $option;
-                    }, $rawOptions)
+                    'attribute_value' => $attr ? $attr->getValue() : null,
+                    'attribute_code' => $attr->getAttributeCode(),
+                    'attribute_type' => $attr->getFrontendInput(),
+                    'attribute_label' => $attr->getFrontendLabel(),
+                    'attribute_id' => $attr->getAttributeId(),
+                    'attribute_options' => $this->getAttributeOptions($attr, $rawOptions)
                 ];
             }
         }

--- a/src/Model/Resolver/Products/DataProvider/Product/CollectionProcessor/AttributeProcessor.php
+++ b/src/Model/Resolver/Products/DataProvider/Product/CollectionProcessor/AttributeProcessor.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessor;
+
+use Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory;
+use Magento\Catalog\Model\ResourceModel\Product\Collection;
+use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessorInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+/**
+ * Adds passed in attributes to product collection results
+ *
+ * {@inheritdoc}
+ */
+class AttributeProcessor implements CollectionProcessorInterface
+{
+    const ATTRIBUTES_FIELD = 'attributes';
+
+    /**
+     * @var CollectionFactory
+     */
+    protected $collectionFactory;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    protected $storeManager;
+
+    /**
+     * FilterableAttributeList constructor
+     *
+     * @param CollectionFactory $collectionFactory
+     * @param StoreManagerInterface $storeManager
+     */
+    public function __construct(
+        CollectionFactory $collectionFactory,
+        StoreManagerInterface $storeManager
+    ) {
+        $this->collectionFactory = $collectionFactory;
+        $this->storeManager = $storeManager;
+    }
+
+    protected function getAttributesVisibleOnFrontend() {
+        $collection = $this->collectionFactory->create();
+        $collection->setItemObjectClass(\Magento\Catalog\Model\ResourceModel\Eav\Attribute::class)
+            ->addStoreLabel($this->storeManager->getStore()->getId())
+            ->setOrder('position', 'ASC');
+
+        // Add filter by storefront visibility
+        $collection->addFieldToFilter('additional_table.is_visible_on_front', ['gt' => 0]);
+        $collection->load();
+
+        return $collection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(
+        Collection $collection,
+        SearchCriteriaInterface $searchCriteria,
+        array $attributeNames
+    ): Collection {
+        foreach ($attributeNames as $name) {
+            if ($name != self::ATTRIBUTES_FIELD) {
+                $collection->addAttributeToSelect($name);
+            } else {
+                $attributesVisibleOnFront = $this->getAttributesVisibleOnFrontend();
+
+                $attributeCodes = array_map(function($attr) {
+                    return $attr->getAttributeCode();
+                }, $attributesVisibleOnFront->getItems());
+
+                $collection->addAttributeToSelect($attributeCodes);
+            }
+        }
+
+        return $collection;
+    }
+}

--- a/src/Model/Resolver/Products/DataProvider/Product/CollectionProcessor/AttributeProcessor.php
+++ b/src/Model/Resolver/Products/DataProvider/Product/CollectionProcessor/AttributeProcessor.php
@@ -70,15 +70,16 @@ class AttributeProcessor implements CollectionProcessorInterface
         foreach ($attributeNames as $name) {
             if ($name != self::ATTRIBUTES_FIELD) {
                 $collection->addAttributeToSelect($name);
-            } else {
-                $attributesVisibleOnFront = $this->getAttributesVisibleOnFrontend();
-
-                $attributeCodes = array_map(function($attr) {
-                    return $attr->getAttributeCode();
-                }, $attributesVisibleOnFront->getItems());
-
-                $collection->addAttributeToSelect($attributeCodes);
+                continue;
             }
+
+            $attributesVisibleOnFront = $this->getAttributesVisibleOnFrontend();
+
+            $attributeCodes = array_map(function($attr) {
+                return $attr->getAttributeCode();
+            }, $attributesVisibleOnFront->getItems());
+
+            $collection->addAttributeToSelect($attributeCodes);
         }
 
         return $collection;

--- a/src/Model/Resolver/Products/DataProvider/Product/CollectionProcessor/AttributeProcessor.php
+++ b/src/Model/Resolver/Products/DataProvider/Product/CollectionProcessor/AttributeProcessor.php
@@ -54,9 +54,7 @@ class AttributeProcessor implements CollectionProcessorInterface
 
         // Add filter by storefront visibility
         $collection->addFieldToFilter('additional_table.is_visible_on_front', ['gt' => 0]);
-        $collection->load();
-
-        return $collection;
+        return $collection->load();
     }
 
     /**
@@ -68,7 +66,7 @@ class AttributeProcessor implements CollectionProcessorInterface
         array $attributeNames
     ): Collection {
         foreach ($attributeNames as $name) {
-            if ($name != self::ATTRIBUTES_FIELD) {
+            if ($name !== self::ATTRIBUTES_FIELD) {
                 $collection->addAttributeToSelect($name);
                 continue;
             }

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -15,7 +15,11 @@
     </type>
 
     <preference for="Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessor\StockProcessor"
-     type="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessor\StockProcessor"/>
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessor\StockProcessor" />
+
+    <preference for="Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessor\AttributeProcessor"
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CollectionProcessor\AttributeProcessor" />
+
 
     <virtualType name="ScandiPWA\CatalogGraphQl\Model\Search\PageSizeProvider" type="Magento\Search\Model\Search\PageSizeProvider">
         <arguments>

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -22,6 +22,11 @@ input ProductFilterInput {
     color: FilterTypeInput @doc(description: "Product color")
     size: FilterTypeInput @doc(description: "Product size")
     shoes_size: FilterTypeInput @doc(description: "Product shoes size")
+    conditions: FilterTypeInput @doc(description: "Searches products by JSON formatted conditions")
+}
+
+input ProductSortInput {
+    position: SortEnum @doc(description: "A number assigned to a product")
 }
 
 type MediaGalleryEntry  @doc(description: "MediaGalleryEntry defines characteristics about images and videos associated with a specific product") {

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -22,11 +22,6 @@ input ProductFilterInput {
     color: FilterTypeInput @doc(description: "Product color")
     size: FilterTypeInput @doc(description: "Product size")
     shoes_size: FilterTypeInput @doc(description: "Product shoes size")
-    conditions: FilterTypeInput @doc(description: "Searches products by JSON formatted conditions")
-}
-
-input ProductSortInput {
-    position: SortEnum @doc(description: "A number assigned to a product")
 }
 
 type MediaGalleryEntry  @doc(description: "MediaGalleryEntry defines characteristics about images and videos associated with a specific product") {


### PR DESCRIPTION
Reworked attributes and rating fields as they were hyper inefficient each loading data on its own.

Now we check for attribute field in request (`AttributeProcessor`). If it is present, we add to select all attributes which are visible on front-end.

Then, when request comes to resolving attributes (`AttributesWithValue`) we get them from product model, instead of loading new product.

In Product Data Provider I have added the code to get the summary once per collection load. Required for this PR: https://github.com/scandipwa/reviews-graphql/pull/2

**NOTE**: function `getAttributesVisibleOnFrontend` is based on `Magento\Catalog\Model\Layer\Category\FilterableAttributeList`.