### PR TITLE
Fix filters count

### DIFF
--- a/src/Model/Resolver/Layer/DataProvider/Filters.php
+++ b/src/Model/Resolver/Layer/DataProvider/Filters.php
@@ -29,6 +29,8 @@ class Filters extends \Magento\CatalogGraphQl\Model\Resolver\Layer\DataProvider\
      */
     private $requiredAttributes = [];
 
+    private $searchCriteria = [];
+
     /**
      * Filters constructor.
      * @param FiltersProvider $filtersProvider
@@ -63,6 +65,14 @@ class Filters extends \Magento\CatalogGraphQl\Model\Resolver\Layer\DataProvider\
         }
 
         $this->requiredAttributes = $attributes;
+
+        return $this;
+    }
+
+    public function setSearchCriteria($searchCriteria)
+    {
+        $this->searchCriteria = $searchCriteria;
+        return $this;
     }
 
     /**
@@ -76,6 +86,7 @@ class Filters extends \Magento\CatalogGraphQl\Model\Resolver\Layer\DataProvider\
         $filtersData = [];
         /** @var AbstractFilter $filter */
         foreach ($this->filtersProvider->getFilters($layerType) as $filter) {
+            $filter->setSearchCriteria($this->searchCriteria);
             if ($filter->getItemsCount() && $this->hasFilterContents($filter)) {
                 $filterGroup = [
                     'name' => (string) $filter->getName(),

--- a/src/Model/Resolver/Layer/Filter/Attribute.php
+++ b/src/Model/Resolver/Layer/Filter/Attribute.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Layer\Filter;
+
+/**
+ * Layer attribute filter
+ *
+ * @SuppressWarnings(PHPMD.LongVariable)
+ */
+class Attribute extends \Magento\Catalog\Model\Layer\Filter\AbstractFilter
+{
+    /**
+     * Resource instance
+     *
+     * @var \Magento\Catalog\Model\ResourceModel\Layer\Filter\Attribute
+     */
+    protected $_resource;
+
+    /**
+     * Magento string lib
+     *
+     * @var \Magento\Framework\Stdlib\StringUtils
+     */
+    protected $string;
+
+    /**
+     * @var \Magento\Framework\Filter\StripTags
+     */
+    protected $tagFilter;
+
+    private $searchCriteria;
+
+    /**
+     * @param ItemFactory $filterItemFactory
+     * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+     * @param \Magento\Catalog\Model\Layer $layer
+     * @param \Magento\Catalog\Model\Layer\Filter\Item\DataBuilder $itemDataBuilder
+     * @param \Magento\Catalog\Model\ResourceModel\Layer\Filter\AttributeFactory $filterAttributeFactory
+     * @param \Magento\Framework\Stdlib\StringUtils $string
+     * @param \Magento\Framework\Filter\StripTags $tagFilter
+     * @param array $data
+     */
+    public function __construct(
+        \Magento\Catalog\Model\Layer\Filter\ItemFactory $filterItemFactory,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Catalog\Model\Layer $layer,
+        \Magento\Catalog\Model\Layer\Filter\Item\DataBuilder $itemDataBuilder,
+        \Magento\Catalog\Model\ResourceModel\Layer\Filter\AttributeFactory $filterAttributeFactory,
+        \Magento\Framework\Stdlib\StringUtils $string,
+        \Magento\Framework\Filter\StripTags $tagFilter,
+        array $data = []
+    ) {
+        $this->_resource = $filterAttributeFactory->create();
+        $this->string = $string;
+        $this->_requestVar = 'attribute';
+        $this->tagFilter = $tagFilter;
+        parent::__construct($filterItemFactory, $storeManager, $layer, $itemDataBuilder, $data);
+    }
+
+    /**
+     * Retrieve resource instance
+     *
+     * @return \Magento\Catalog\Model\ResourceModel\Layer\Filter\Attribute
+     */
+    protected function _getResource()
+    {
+        return $this->_resource;
+    }
+
+    public function setSearchCriteria($searchCriteria)
+    {
+        $this->searchCriteria = $searchCriteria;
+        return $this;
+    }
+
+    /**
+     * Apply attribute option filter to product collection
+     *
+     * @param   \Magento\Framework\App\RequestInterface $request
+     * @return  $this
+     */
+    public function apply(\Magento\Framework\App\RequestInterface $request)
+    {
+        $filter = $request->getParam($this->_requestVar);
+        if (is_array($filter)) {
+            return $this;
+        }
+        $text = $this->getOptionText($filter);
+        if ($filter && strlen($text)) {
+            $this->_getResource()->applyFilterToCollection($this, $filter);
+            $this->getLayer()->getState()->addFilter($this->_createItem($text, $filter));
+            $this->_items = [];
+        }
+        return $this;
+    }
+
+    /**
+     * Get data array for building attribute filter items
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @return array
+     */
+    protected function _getItemsData()
+    {
+        $attribute = $this->getAttributeModel();
+        $this->_requestVar = $attribute->getAttributeCode();
+
+        $options = $attribute->getFrontend()->getSelectOptions();
+        $resource = $this->_getResource();
+        $resource->setSearchCriteria($this->searchCriteria);
+        $optionsCount = $resource->getCount($this);
+        foreach ($options as $option) {
+            if (is_array($option['value'])) {
+                continue;
+            }
+            if ($this->string->strlen($option['value'])) {
+                // Check filter type
+                if ($this->getAttributeIsFilterable($attribute) == self::ATTRIBUTE_OPTIONS_ONLY_WITH_RESULTS) {
+                    if (!empty($optionsCount[$option['value']])) {
+                        $this->itemDataBuilder->addItemData(
+                            $this->tagFilter->filter($option['label']),
+                            $option['value'],
+                            $optionsCount[$option['value']]
+                        );
+                    }
+                } else {
+                    $this->itemDataBuilder->addItemData(
+                        $this->tagFilter->filter($option['label']),
+                        $option['value'],
+                        isset($optionsCount[$option['value']]) ? $optionsCount[$option['value']] : 0
+                    );
+                }
+            }
+        }
+
+        return $this->itemDataBuilder->build();
+    }
+}

--- a/src/Model/Resolver/LayerFilters.php
+++ b/src/Model/Resolver/LayerFilters.php
@@ -48,7 +48,9 @@ class LayerFilters extends \Magento\CatalogGraphQl\Model\Resolver\LayerFilters i
             return null;
         }
 
-        $this->filtersDataProvider->setRequiredAttributesFromItems($value['items'] ?? []);
+        $this->filtersDataProvider
+            ->setRequiredAttributesFromItems($value['items'] ?? [])
+            ->setSearchCriteria($value['searchCriteria'] ?? []);
 
         return $this->filtersDataProvider->getData($value['layer_type']);
     }

--- a/src/Model/Resolver/Products.php
+++ b/src/Model/Resolver/Products.php
@@ -119,6 +119,7 @@ class Products implements ResolverInterface
                 'current_page' => $currentPage,
                 'total_pages' => $maxPages
             ],
+            'searchCriteria' => $searchCriteria,
             'layer_type' => $layerType
         ];
 

--- a/src/Model/Resolver/Products/SearchCriteria/CollectionProcessor/ExclusiveFilterProcessor.php
+++ b/src/Model/Resolver/Products/SearchCriteria/CollectionProcessor/ExclusiveFilterProcessor.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Artjoms Travkovs <info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
+ */
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchCriteria\CollectionProcessor;
+
+use Magento\Framework\Api\Search\FilterGroup;
+use Magento\Framework\Data\Collection\AbstractDb;
+
+class ExclusiveFilterProcessor extends FilterProcessor
+{
+
+    private $ignoredFilters = [];
+
+    public function setIgnoredFilters($ignoredFilters)
+    {
+        $this->ignoredFilters = $ignoredFilters;
+
+        return $this;
+    }
+
+    /**
+     * Add FilterGroup to the collection
+     *
+     * @param FilterGroup $filterGroup
+     * @param AbstractDb $collection
+     * @return void
+     */
+    protected function addFilterGroupToCollection(
+        FilterGroup $filterGroup,
+        AbstractDb $collection
+    ) {
+        foreach ($filterGroup->getFilters() as $filter) {
+            if (in_array($filter->getField(), $this->ignoredFilters)) {
+                continue;
+            }
+
+            $isApplied = false;
+            $customFilter = $this->getCustomFilterForField($filter->getField());
+
+            if ($customFilter) {
+                $isApplied = $customFilter->apply($filter, $collection);
+            }
+
+            if (!$isApplied) {
+                $filter->setField($this->getFieldMapping($filter->getField()));
+                $this->defaultFilter->apply($filter, $collection);
+            }
+        }
+    }
+}

--- a/src/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor.php
+++ b/src/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor.php
@@ -20,17 +20,17 @@ class FilterProcessor implements CollectionProcessorInterface
     /**
      * @var CustomFilterInterface[]
      */
-    private $customFilters;
+    protected $customFilters;
 
     /**
      * @var array
      */
-    private $fieldMapping;
+    protected $fieldMapping;
 
     /**
      * @var CustomFilterInterface
      */
-    private $defaultFilter;
+    protected $defaultFilter;
 
     /**
      * @param CustomFilterInterface $defaultFilter

--- a/src/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor.php
+++ b/src/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor.php
@@ -32,7 +32,6 @@ class FilterProcessor implements CollectionProcessorInterface
      */
     private $defaultFilter;
 
-
     /**
      * @param CustomFilterInterface $defaultFilter
      * @param CustomFilterInterface[] $customFilters
@@ -69,7 +68,7 @@ class FilterProcessor implements CollectionProcessorInterface
      * @param AbstractDb $collection
      * @return void
      */
-    private function addFilterGroupToCollection(
+    protected function addFilterGroupToCollection(
         FilterGroup $filterGroup,
         AbstractDb $collection
     ) {
@@ -95,7 +94,7 @@ class FilterProcessor implements CollectionProcessorInterface
      * @return CustomFilterInterface|null
      * @throws \InvalidArgumentException
      */
-    private function getCustomFilterForField($field)
+    protected function getCustomFilterForField($field)
     {
         $filter = null;
         if (isset($this->customFilters[$field])) {
@@ -119,7 +118,7 @@ class FilterProcessor implements CollectionProcessorInterface
      * @param string $field
      * @return string
      */
-    private function getFieldMapping($field)
+    protected function getFieldMapping($field)
     {
         return isset($this->fieldMapping[$field]) ? $this->fieldMapping[$field] : $field;
     }

--- a/src/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor/CategoryFilter.php
+++ b/src/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor/CategoryFilter.php
@@ -88,7 +88,10 @@ class CategoryFilter implements CustomFilterInterface
             ->addAttributeToSelect(['entity_id'])->getFirstItem()->getEntityId();
 
         $this->categoryResourceModel->load($category, $categoryId);
-        $this->registry->register('current_category', $category);
+
+        if (!$this->registry->registry('current_category')) {
+            $this->registry->register('current_category', $category);
+        }
 
         $collection->addCategoryFilter($category);
 

--- a/src/Model/ResourceModel/Layer/Filter/Attribute.php
+++ b/src/Model/ResourceModel/Layer/Filter/Attribute.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace ScandiPWA\CatalogGraphQl\Model\ResourceModel\Layer\Filter;
 
+use Magento\Framework\Registry;
 use Magento\Catalog\Model\Layer\Filter\FilterInterface;
 
 /**
@@ -20,6 +21,21 @@ use Magento\Catalog\Model\Layer\Filter\FilterInterface;
 class Attribute extends \Magento\Catalog\Model\ResourceModel\Layer\Filter\Attribute
 {
     /**
+     * @var Registry
+     */
+    protected $registry;
+
+    public function __construct(
+        \Magento\Framework\Model\ResourceModel\Db\Context $context,
+        $connectionName = null,
+        Registry $registry
+    )
+    {
+        parent::__construct($context, $connectionName);
+        $this->registry = $registry;
+    }
+
+    /**
      * Retrieve array with products counts per attribute option
      *
      * @param FilterInterface $filter
@@ -28,7 +44,14 @@ class Attribute extends \Magento\Catalog\Model\ResourceModel\Layer\Filter\Attrib
      */
     public function getCount(FilterInterface $filter)
     {
-        $select = clone $filter->getLayer()->getProductCollection()->getSelect();
+        $productCollection = clone $filter->getLayer()->getProductCollection();
+
+        $category = $this->registry->registry('current_category');
+        if ($category) {
+            $productCollection->addCategoriesFilter(['in' => (int)$category->getId()]);
+        }
+
+        $select = $productCollection->getSelect();
         // reset columns, order and limitation conditions
         $select->reset(\Magento\Framework\DB\Select::COLUMNS);
         $select->reset(\Magento\Framework\DB\Select::ORDER);

--- a/src/Model/ResourceModel/Layer/Filter/Attribute.php
+++ b/src/Model/ResourceModel/Layer/Filter/Attribute.php
@@ -4,14 +4,13 @@
  *
  * @category    ScandiPWA
  * @package     ScandiPWA_CatalogGraphQl
- * @author      Kirils Scerba <kirill@scandiweb.com | info@scandiweb.com>
+ * @author      Artjoms Travkovs <info@scandiweb.com>
  * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
  */
+declare(strict_types=1);
 
 namespace ScandiPWA\CatalogGraphQl\Model\ResourceModel\Layer\Filter;
 
-use Magento\Catalog\Helper\Data as CatalogHelper;
-use Magento\Framework\Model\ResourceModel\Db\Context;
 use Magento\Catalog\Model\Layer\Filter\FilterInterface;
 
 /**
@@ -21,26 +20,6 @@ use Magento\Catalog\Model\Layer\Filter\FilterInterface;
 class Attribute extends \Magento\Catalog\Model\ResourceModel\Layer\Filter\Attribute
 {
     /**
-     * @var CatalogHelper
-     */
-    protected $catalogHelper;
-
-    /**
-     * @param CatalogHelper $catalogHelper
-     * @param Context $context
-     * @param null $connectionName
-     */
-    public function __construct(
-        Context $context,
-        CatalogHelper $catalogHelper,
-        $connectionName = null
-    )
-    {
-        $this->catalogHelper = $catalogHelper;
-        parent::__construct($context, $connectionName);
-    }
-
-    /**
      * Retrieve array with products counts per attribute option
      *
      * @param FilterInterface $filter
@@ -49,12 +28,7 @@ class Attribute extends \Magento\Catalog\Model\ResourceModel\Layer\Filter\Attrib
      */
     public function getCount(FilterInterface $filter)
     {
-        $category = $this->catalogHelper->getCategory();
-
-        $productCollection = clone $filter->getLayer()->getProductCollection();
-        $productCollection->addCategoriesFilter([ 'in' => (int) $category->getId() ]);
-
-        $select = $productCollection->getSelect();
+        $select = clone $filter->getLayer()->getProductCollection()->getSelect();
         // reset columns, order and limitation conditions
         $select->reset(\Magento\Framework\DB\Select::COLUMNS);
         $select->reset(\Magento\Framework\DB\Select::ORDER);

--- a/src/Model/ResourceModel/Layer/Filter/Attribute.php
+++ b/src/Model/ResourceModel/Layer/Filter/Attribute.php
@@ -27,7 +27,7 @@ class Attribute extends \Magento\Catalog\Model\ResourceModel\Layer\Filter\Attrib
     public function __construct(
         \Magento\Framework\Model\ResourceModel\Db\Context $context,
         $connectionName = null,
-        \ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchCriteria\CollectionProcessor\ExclusiveFilterProcessor $filterProcessor
+        \Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface $filterProcessor
     ) {
         parent::__construct($context, $connectionName);
         $this->filterProcessor = $filterProcessor;
@@ -51,11 +51,10 @@ class Attribute extends \Magento\Catalog\Model\ResourceModel\Layer\Filter\Attrib
         $attribute = $filter->getAttributeModel();
         $productCollection = clone $filter->getLayer()->getProductCollection();
 
-        // echo 'Couont: '  . count($this->searchCriteria->ge
-
-        $this->filterProcessor
-            ->setIgnoredFilters([$attribute->getAttributeCode()])
-            ->process($this->searchCriteria, $productCollection);
+        if ($this->searchCriteria) {
+            $this->filterProcessor->setIgnoredFilters([$attribute->getAttributeCode()]);
+            $this->filterProcessor->process($this->searchCriteria, $productCollection);
+        }
 
         $select = $productCollection->getSelect();
         // reset columns, order and limitation conditions

--- a/src/Model/ResourceModel/Layer/Filter/Attribute.php
+++ b/src/Model/ResourceModel/Layer/Filter/Attribute.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Kirils Scerba <kirill@scandiweb.com | info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
+ */
+
+namespace ScandiPWA\CatalogGraphQl\Model\ResourceModel\Layer\Filter;
+
+use Magento\Catalog\Helper\Data as CatalogHelper;
+use Magento\Framework\Model\ResourceModel\Db\Context;
+use Magento\Catalog\Model\Layer\Filter\FilterInterface;
+
+/**
+ * Class Attribute
+ * @package ScandiPWA\CatalogGraphQl\Model\ResourceModel\Layer\Filter
+ */
+class Attribute extends \Magento\Catalog\Model\ResourceModel\Layer\Filter\Attribute
+{
+    /**
+     * @var CatalogHelper
+     */
+    protected $catalogHelper;
+
+    /**
+     * @param CatalogHelper $catalogHelper
+     * @param Context $context
+     * @param null $connectionName
+     */
+    public function __construct(
+        Context $context,
+        CatalogHelper $catalogHelper,
+        $connectionName = null
+    )
+    {
+        $this->catalogHelper = $catalogHelper;
+        parent::__construct($context, $connectionName);
+    }
+
+    /**
+     * Retrieve array with products counts per attribute option
+     *
+     * @param FilterInterface $filter
+     * @return array
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getCount(FilterInterface $filter)
+    {
+        $category = $this->catalogHelper->getCategory();
+
+        $productCollection = clone $filter->getLayer()->getProductCollection();
+        $productCollection->addCategoriesFilter([ 'in' => (int) $category->getId() ]);
+
+        $select = $productCollection->getSelect();
+        // reset columns, order and limitation conditions
+        $select->reset(\Magento\Framework\DB\Select::COLUMNS);
+        $select->reset(\Magento\Framework\DB\Select::ORDER);
+        $select->reset(\Magento\Framework\DB\Select::LIMIT_COUNT);
+        $select->reset(\Magento\Framework\DB\Select::LIMIT_OFFSET);
+
+        $connection = $this->getConnection();
+        $attribute = $filter->getAttributeModel();
+        $tableAlias = sprintf('%s_idx', $attribute->getAttributeCode());
+        $conditions = [
+            "{$tableAlias}.entity_id = e.entity_id",
+            $connection->quoteInto("{$tableAlias}.attribute_id = ?", $attribute->getAttributeId()),
+            $connection->quoteInto("{$tableAlias}.store_id = ?", $filter->getStoreId()),
+        ];
+
+        $select->join(
+            [$tableAlias => $this->getMainTable()],
+            join(' AND ', $conditions),
+            ['value', 'entity_id']
+        );
+
+        $results = $connection->fetchAll($select);
+
+        return $this->countFilters($results);
+    }
+
+    /**
+     * Counts filters
+     *
+     * @param array $results
+     * @return array
+     */
+    protected function countFilters(array $results): array
+    {
+        $resultArr = [];
+        $existingEntities = [];
+
+        foreach ($results as list('value' => $key, 'entity_id' => $entityId)) {
+            if (!array_key_exists($key, $resultArr)) {
+                $resultArr[$key] = 1;
+                $existingEntities[$key][] = $entityId;
+            } elseif (!in_array($entityId, $existingEntities[$key])) {
+                $resultArr[$key]++;
+                $existingEntities[$key][] = $entityId;
+            }
+        }
+
+        return $resultArr;
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -94,6 +94,9 @@
     <preference for="Magento\CatalogGraphQl\Model\Resolver\LayerFilters"
                 type="ScandiPWA\CatalogGraphQl\Model\Resolver\LayerFilters" />
 
+    <preference for="Magento\Catalog\Model\Layer\Filter\Attribute"
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Layer\Filter\Attribute" />
+
     <type name="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\Query\Search">
         <arguments>
             <argument name="pageSize" xsi:type="object">ScandiPWA\CatalogGraphQl\Model\Search\PageSizeProvider</argument>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -94,9 +94,6 @@
     <preference for="Magento\CatalogGraphQl\Model\Resolver\LayerFilters"
                 type="ScandiPWA\CatalogGraphQl\Model\Resolver\LayerFilters" />
 
-    <preference for="Magento\Catalog\Model\Layer\Filter\Attribute"
-                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Layer\Filter\Attribute" />
-
     <type name="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\Query\Search">
         <arguments>
             <argument name="pageSize" xsi:type="object">ScandiPWA\CatalogGraphQl\Model\Search\PageSizeProvider</argument>

--- a/src/etc/graphql/di.xml
+++ b/src/etc/graphql/di.xml
@@ -31,9 +31,38 @@
         </arguments>
     </virtualType>
 
+    <virtualType name="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchCriteria\CollectionProcessor\ExcludingProductFilterProcessor" type="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchCriteria\CollectionProcessor\ExclusiveFilterProcessor">
+        <arguments>
+            <argument name="customFilters" xsi:type="array">
+                <item name="conditions" xsi:type="object">ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchCriteria\CollectionProcessor\FilterProcessor\ConditionsFilter</item>
+                <item name="category_url_key" xsi:type="object">ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchCriteria\CollectionProcessor\FilterProcessor\CategoryFilter</item>
+                <item name="category_url_path" xsi:type="object">ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchCriteria\CollectionProcessor\FilterProcessor\CategoryFilter</item>
+
+                <item name="price" xsi:type="object">Magento\Catalog\Model\Api\SearchCriteria\CollectionProcessor\FilterProcessor\ProductPriceFilter</item>
+                <item name="min_price" xsi:type="object">Magento\Catalog\Model\Api\SearchCriteria\CollectionProcessor\FilterProcessor\ProductPriceFilter</item>
+                <item name="max_price" xsi:type="object">Magento\Catalog\Model\Api\SearchCriteria\CollectionProcessor\FilterProcessor\ProductPriceFilter</item>
+                <item name="category_id" xsi:type="object">Magento\CatalogGraphQl\Model\Resolver\Products\SearchCriteria\CollectionProcessor\FilterProcessor\CategoryFilter</item>
+
+                <item name="store" xsi:type="object">Magento\Catalog\Model\Api\SearchCriteria\CollectionProcessor\FilterProcessor\ProductStoreFilter</item>
+                <item name="store_id" xsi:type="object">Magento\Catalog\Model\Api\SearchCriteria\CollectionProcessor\FilterProcessor\ProductStoreFilter</item>
+                <item name="website_id" xsi:type="object">Magento\Catalog\Model\Api\SearchCriteria\CollectionProcessor\FilterProcessor\ProductWebsiteFilter</item>
+            </argument>
+            <argument name="defaultFilter" xsi:type="object">ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchCriteria\CollectionProcessor\FilterProcessor\ConfigurableProductAttributeFilter</argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="ScandiPWA\CatalogGraphQl\Model\Resolver\Layer\Filter\FilteredAttribute" type="ScandiPWA\CatalogGraphQl\Model\ResourceModel\Layer\Filter\Attribute">
+        <arguments>
+            <argument name="filterProcessor" xsi:type="object">ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchCriteria\CollectionProcessor\ExcludingProductFilterProcessor</argument>
+        </arguments>
+    </virtualType>
+
     <preference for="Magento\Catalog\Model\ResourceModel\Layer\Filter\Attribute"
-                type="ScandiPWA\CatalogGraphQl\Model\ResourceModel\Layer\Filter\Attribute" />
-  
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Layer\Filter\FilteredAttribute" />
+
     <preference for="Magento\Catalog\Model\Api\SearchCriteria\CollectionProcessor\ProductFilterProcessor"
                 type="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\SearchCriteria\CollectionProcessor\ProductFilterProcessor" />
+
+    <preference for="Magento\Catalog\Model\Layer\Filter\Attribute"
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Layer\Filter\Attribute" />
 </config>

--- a/src/etc/graphql/di.xml
+++ b/src/etc/graphql/di.xml
@@ -22,4 +22,7 @@
             </argument>
         </arguments>
     </virtualType>
+
+    <preference for="Magento\Catalog\Model\ResourceModel\Layer\Filter\Attribute"
+                type="ScandiPWA\CatalogGraphQl\Model\ResourceModel\Layer\Filter\Attribute" />
 </config>


### PR DESCRIPTION
Previously `items_count` for filters were inaccurate, as it has been showing how many products with this attribute were in all categories and counted in even configurable options, this PR is solving described issues, to make data more accurate.

Also add categories filter