### PR TITLE
Category URL key giving variants as null in GraphQL #483

### DIFF
--- a/src/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor/CategoryFilter.php
+++ b/src/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor/CategoryFilter.php
@@ -20,7 +20,6 @@ use Magento\Framework\Api\Filter;
 use Magento\Framework\Api\SearchCriteria\CollectionProcessor\FilterProcessor\CustomFilterInterface;
 use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Registry;
 
 /**
  * Category filter allows to filter products collection using custom defined filters from search criteria.
@@ -50,13 +49,11 @@ class CategoryFilter implements CustomFilterInterface
     public function __construct(
         CategoryFactory $categoryFactory,
         CategoryResourceModel $categoryResourceModel,
-        CategoryResourceCollection $categoryResourceCollection,
-        Registry $registry
+        CategoryResourceCollection $categoryResourceCollection
     ) {
         $this->categoryFactory = $categoryFactory;
         $this->categoryResourceModel = $categoryResourceModel;
         $this->categoryResourceCollection = $categoryResourceCollection;
-        $this->registry = $registry;
     }
 
     /**
@@ -88,7 +85,6 @@ class CategoryFilter implements CustomFilterInterface
             ->addAttributeToSelect(['entity_id'])->getFirstItem()->getEntityId();
 
         $this->categoryResourceModel->load($category, $categoryId);
-        $this->registry->register('current_category', $category);
 
         $collection->addCategoryFilter($category);
 

--- a/src/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor/ConfigurableProductAttributeFilter.php
+++ b/src/Model/Resolver/Products/SearchCriteria/CollectionProcessor/FilterProcessor/ConfigurableProductAttributeFilter.php
@@ -25,33 +25,42 @@ use Magento\Framework\Registry;
  */
 class ConfigurableProductAttributeFilter implements CustomFilterInterface
 {
+    /**
+     * @var Configurable
+     */
     protected $configurable;
+    /**
+     * @var CollectionFactory
+     */
     protected $collectionFactory;
-    protected $registry;
 
+    /**
+     * ConfigurableProductAttributeFilter constructor.
+     * @param Configurable $configurable
+     * @param CollectionFactory $collectionFactory
+     */
     public function __construct(
         Configurable $configurable,
-        CollectionFactory $collectionFactory,
-        Registry $registry
+        CollectionFactory $collectionFactory
     ) {
-        $this->registry = $registry;
         $this->configurable = $configurable;
         $this->collectionFactory = $collectionFactory;
     }
 
+    /**
+     * @param Filter $filter
+     * @param AbstractDb $collection
+     * @return bool
+     */
     public function apply(Filter $filter, AbstractDb $collection)
     {
         $attributeName = $filter->getField();
         $attributeValue = $filter->getValue();
         $conditionType = $filter->getConditionType();
-        $category = $this->registry->registry('current_category');
 
         $simpleSelect = $this->collectionFactory->create()
             ->addAttributeToFilter($attributeName, [$conditionType => $attributeValue])
             ->addAttributeToFilter('status', Status::STATUS_ENABLED);
-        if ($category) {
-            $simpleSelect->addCategoriesFilter(['in' => (int)$category->getId()]);
-        }
 
 
         $simpleSelect->getSelect()


### PR DESCRIPTION
[Category URL key giving variants as null](https://github.com/scandipwa/base-theme/issues/483)

**Description**
GraphQL returns null value for variants of configurable products when fetched using category_url_key.

**Steps to Reproduce**

1. Create a test category.
2. Create a configurable product and assign it the test category created in step 1.
3. Add child products in the configurable product created in step 2 but without assigning category.
4. Fetch products of test category created in step 1 using GraphQL request using category_url_key.
5. The variants of configurable product will be null in the result fetched in step 3.

**Expected behavior**
Configurable product data along with its variants data.