### PR TITLE
Solve 'cannot function as a GraphQL resolver'

### DIFF
--- a/src/Model/Resolver/ConfigurableVariant.php
+++ b/src/Model/Resolver/ConfigurableVariant.php
@@ -26,13 +26,14 @@ use Magento\Store\Model\StoreManagerInterface;
 use ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product\CriteriaCheck;
 use ScandiPWA\Performance\Model\Resolver\Products\DataPostProcessor;
 use ScandiPWA\Performance\Model\Resolver\ResolveInfoFieldsTrait;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
 
 /**
  * Class ConfigurableVariant
  *
  * @package ScandiPWA\CatalogGraphQl\Model\Resolver
  */
-class ConfigurableVariant
+class ConfigurableVariant implements ResolverInterface
 {
     use ResolveInfoFieldsTrait;
 


### PR DESCRIPTION
Happens because all resolvers need to implement ResolverInterface as `Magento\ConfigurableProductGraphQl\Model\Resolver\Magento\ConfigurableProductGraphQl\Model\Resolver` does.

Error coming from `Magento\Framework\GraphQl\Query\Resolver\Factory`