### PR TITLE
Fixed: Not picking table prefix #64

### DIFF
--- a/src/Model/AttributeDbProvider.php
+++ b/src/Model/AttributeDbProvider.php
@@ -62,13 +62,15 @@ class AttributeDbProvider
         $fieldsUsedInQuery = $this->queryFields->getFieldsUsedInQuery();
         $connection = $this->connection->getConnection();
         $placeHolders = str_repeat('?,', count($fieldsUsedInQuery) - 1) . '?';
-        $sql = "SELECT eav_attribute.attribute_code
-FROM eav_attribute
-WHERE eav_attribute.attribute_id IN (
-    SELECT catalog_eav_attribute.attribute_id
-    FROM catalog_eav_attribute
-    WHERE catalog_eav_attribute.is_filterable = 1
-) AND eav_attribute.attribute_code IN ($placeHolders)";
+        $eavAttribute = $this->connection->getTableName('eav_attribute');
+        $catalogEavAttribute = $this->connection->getTableName('catalog_eav_attribute');
+        $sql = "SELECT {$eavAttribute}.attribute_code
+        FROM {$eavAttribute}
+        WHERE {$eavAttribute}.attribute_id IN (
+            SELECT {$catalogEavAttribute}.attribute_id
+            FROM {$catalogEavAttribute}
+            WHERE {$catalogEavAttribute}.is_filterable = 1
+        ) AND {$eavAttribute}.attribute_code IN ($placeHolders)";
         $query = $connection->query($sql, array_keys($fieldsUsedInQuery));
 
         return $query->fetchAll(\PDO::FETCH_COLUMN);

--- a/src/Model/Variant/Collection.php
+++ b/src/Model/Variant/Collection.php
@@ -224,7 +224,7 @@ class Collection
         $conn = $this->connection->getConnection();
         $select = $conn->select()
             ->from(
-                ['s' => 'catalog_product_super_link'],
+                ['s' => $this->connection->getTableName('catalog_product_super_link')],
                 ['product_id', 'parent_id']
             )
             ->where('s.parent_id IN (?)', $parentIds);


### PR DESCRIPTION
Fixed: Not picking table prefix #64

**Description**:

I am using a prefix for my table but it doesn't pick the prefix
it find the table without prefix

**Expected behavior**:
it should work with prefix also 

**Screenshots, Video, Logs**
{"errors":[{"debugMessage":"SQLSTATE[42S02]: Base table or view not found: 1146 Table 'magento_2.eav_attribute' doesn't exist, query was: SELECT eav_attribute.attribute_code\nFROM eav_attribute\nWHERE eav_attribute.attribute_id IN (\n    SELECT catalog_eav_attribute.attribute_id\n    FROM catalog_eav_attribute\n    WHERE catalog_eav_attribute.is_filterable = 1\n) AND eav_attribute.attribute_code IN (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)","message":"Internal server error","extensions":{"category":"internal"},"path":["products"]}],"data":{"products":null}}

I checked the code here it is written statically 
![image](https://user-images.githubusercontent.com/56184739/93853915-653c3e00-fcd2-11ea-9b69-3985c3fccf97.png)


**To Reproduce**:
add new product slider you will get this error if you are using the prefix for table

**Versions**:
magento 2.3.5-p2
scandipwa 3.1
