### PR TITLE
Returning all product children when requested by category_id

### DIFF
--- a/src/Model/Variant/Collection.php
+++ b/src/Model/Variant/Collection.php
@@ -183,7 +183,6 @@ class Collection
                 switch ($filter->getField()) {
                     // if this is a category filter, continue, or if we ignore filters, return true
                     case 'category_url_path':
-                    case 'category_id':
                     case 'price':
                         if ($includeFilters) {
                             return true;


### PR DESCRIPTION
Returning all product children when requested by category_id. Fixes https://github.com/scandipwa/base-theme/issues/1006.