### PR TITLE
#2304 Downloadable product samples title and url

### DIFF
--- a/src/Model/Resolver/Product/SampleUrl.php
+++ b/src/Model/Resolver/Product/SampleUrl.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      <info@scandiweb.com>
+ * @copyright   Copyright (c) 2018 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Product;
+
+use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\Resolver\Value;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Downloadable\Model\Link;
+use Magento\Downloadable\Model\LinkFactory;
+
+/**
+ * Class SamplesTitle
+ * @package ScandiPWA\CatalogGraphQl\Model\Resolver\Product
+ */
+class SampleUrl implements ResolverInterface {
+
+    /**
+     * @var LinkFactory
+     */
+    protected $_linkFactory;
+
+    /**
+     * SampleUrl constructor.
+     * @param LinkFactory $linkRepository
+     * @param Link $link
+     */
+    public function __construct(
+        LinkFactory $linkRepository
+    ) {
+        $this->_linkFactory = $linkRepository;
+    }
+
+    /**
+     * Fetches the data from persistence models and format it according to the GraphQL schema.
+     *
+     * @param Field $field
+     * @param ContextInterface $context
+     * @param ResolveInfo $info
+     * @param array|null $value
+     * @param array|null $args
+     * @throws \Exception
+     * @return mixed|Value
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        $linkId = $value['id'];
+
+        /** @var Link $link */
+        $link = $this->_linkFactory->create()->load($linkId);
+
+        return ($link->getSampleFile() || $link->getSampleUrl()) ? $value['sample_url'] : '';
+    }
+}

--- a/src/Model/Resolver/Product/SamplesTitle.php
+++ b/src/Model/Resolver/Product/SamplesTitle.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      <info@scandiweb.com>
+ * @copyright   Copyright (c) 2018 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Product;
+
+use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\Resolver\Value;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Catalog\Model\Product;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Downloadable\Model\Sample;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
+
+/**
+ * Class SamplesTitle
+ * @package ScandiPWA\CatalogGraphQl\Model\Resolver\Product
+ */
+class SamplesTitle implements ResolverInterface {
+
+    const TYPE_DOWNLOADABLE = 'downloadable';
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    protected $_scopeConfig;
+
+    /**
+     * SamplesTitle constructor.
+     * @param ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(
+        ScopeConfigInterface $scopeConfig
+    ) {
+        $this->_scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * Fetches the data from persistence models and format it according to the GraphQL schema.
+     *
+     * @param Field $field
+     * @param ContextInterface $context
+     * @param ResolveInfo $info
+     * @param array|null $value
+     * @param array|null $args
+     * @throws \Exception
+     * @return mixed|Value
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+
+        /** @var Product $product */
+        $product = $value['model'];
+
+        return $product->getId() && $product->getTypeId() === self::TYPE_DOWNLOADABLE ?
+            $product->getSamplesTitle() :
+            $this->_scopeConfig->getValue(
+                Sample::XML_PATH_SAMPLES_TITLE,
+                ScopeInterface::SCOPE_STORE
+            );
+    }
+}

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -87,3 +87,11 @@ type Currency {
 extend type Products {
     aggregations: [Aggregation] @doc(description: "Layered navigation aggregations.") @resolver(class: "ScandiPWA\\CatalogGraphQl\\Model\\Resolver\\Aggregations")
 }
+
+type DownloadableProduct {
+    samples_title: String @resolver(class: "ScandiPWA\\CatalogGraphQl\\Model\\Resolver\\Product\\SamplesTitle")
+}
+
+type DownloadableProductLinks {
+    sample_url: String @resolver(class: "ScandiPWA\\CatalogGraphQl\\Model\\Resolver\\Product\\SampleUrl")
+}


### PR DESCRIPTION
Original issue: [2304](https://github.com/scandipwa/scandipwa/issues/2304)

In this PR:
* Added graphQl support for downloadable product samples title (new field 'samples_title');
* Modified return of 'sample_url' so that only links with existing/attached sample file/URL would return URL address.