### PR TITLE
Bugfix/2479/improve bundle price calculation

### DIFF
--- a/src/Model/Resolver/Product/BundleProductOptions.php
+++ b/src/Model/Resolver/Product/BundleProductOptions.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Product;
+
+use Magento\Bundle\Model\Product\Price;
+use Magento\Bundle\Model\Product\Type as Bundle;
+use Magento\Catalog\Helper\Data as CatalogData;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\GraphQl\Query\EnumLookup;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+
+/**
+ * @inheritdoc
+ */
+class BundleProductOptions implements ResolverInterface
+{
+    /**
+     * Catalog data
+     *
+     * @var CatalogData
+     */
+    protected $catalogData;
+
+    /**
+     * @var EnumLookup
+     */
+    private $enumLookup;
+
+
+    /**
+     * @param CatalogData $catalogData
+     * @param EnumLookup $enumLookup
+     */
+    public function __construct(
+        EnumLookup $enumLookup,
+        CatalogData $catalogData
+    )
+    {
+        $this->enumLookup = $enumLookup;
+        $this->catalogData = $catalogData;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+
+        /** @var \Magento\Bundle\Model\Product\Type $product */
+        $bundleProduct = $value['model'];
+
+        if($bundleProduct->getTypeId() !== Bundle::TYPE_CODE){
+            return [];
+        }
+
+        /** @var \Magento\Bundle\Model\Product\Price $priceModel */
+        $priceModel = $bundleProduct->getPriceModel();
+
+        $result = [];
+
+        /** @var \Magento\Bundle\Model\Option $bundleOption */
+        foreach ($priceModel->getOptions($bundleProduct) as $bundleOption) {
+
+            $selectionsResult = [];
+
+            /* @var \Magento\Bundle\Model\Selection $optionSelection */
+            foreach ($bundleOption->getSelections() as $optionSelection) {
+                // For bundle with fix price taxes are calculated based on the bundle product itself
+                // For bundle with dynamic price taxes are calculated based on the referenced products
+                $taxableItem = $bundleProduct->getPriceType() == Price::PRICE_TYPE_FIXED ? $bundleProduct : $optionSelection;
+
+                $selectionPrice = $priceModel->getSelectionPrice($bundleProduct, $optionSelection, 1);
+                $selectionPriceExclTax = $this->catalogData->getTaxPrice($taxableItem, $selectionPrice, false);
+
+                $selectionPriceType = $this->enumLookup->getEnumValueFromField(
+                    'PriceTypeEnum',
+                    (string) $optionSelection->getSelectionPriceType()
+                ) ?: 'DYNAMIC';
+
+                $regularPrice = $bundleProduct->getPriceType() == Price::PRICE_TYPE_FIXED
+                    ? $selectionPriceType == 'PERCENT'
+                        ? ($bundleProduct->getPrice() * ($optionSelection->getSelectionPriceValue() / 100))
+                        : $optionSelection->getSelectionPriceValue()
+                    : $optionSelection->getPrice();
+
+                $regularPriceExclTax = $this->catalogData->getTaxPrice($taxableItem, $regularPrice, false);
+
+                $selectionsResult[] = [
+                    'selection_id' => $optionSelection->getSelectionId(),
+                    'regular_option_price' => $regularPrice,
+                    'regular_option_price_excl_tax' => $regularPriceExclTax,
+                    'final_option_price' => $selectionPrice,
+                    'final_option_price_excl_tax' => $selectionPriceExclTax
+                ];
+            }
+
+            $result[] = [
+                'option_id' => $bundleOption->getId(),
+                'selection_details' => $selectionsResult
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/src/Model/Resolver/Product/BundleProductOptions.php
+++ b/src/Model/Resolver/Product/BundleProductOptions.php
@@ -15,6 +15,7 @@ use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Framework\GraphQl\Query\EnumLookup;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
 
 /**
  * @inheritdoc
@@ -33,6 +34,10 @@ class BundleProductOptions implements ResolverInterface
      */
     private $enumLookup;
 
+    /**
+     * @var PriceCurrencyInterface
+     */
+    private PriceCurrencyInterface $priceCurrency;
 
     /**
      * @param CatalogData $catalogData
@@ -40,11 +45,13 @@ class BundleProductOptions implements ResolverInterface
      */
     public function __construct(
         EnumLookup $enumLookup,
-        CatalogData $catalogData
+        CatalogData $catalogData,
+        PriceCurrencyInterface $priceCurrency
     )
     {
         $this->enumLookup = $enumLookup;
         $this->catalogData = $catalogData;
+        $this->priceCurrency = $priceCurrency;
     }
 
     /**
@@ -102,10 +109,10 @@ class BundleProductOptions implements ResolverInterface
 
                 $selectionsResult[] = [
                     'selection_id' => $optionSelection->getSelectionId(),
-                    'regular_option_price' => $regularPrice,
-                    'regular_option_price_excl_tax' => $regularPriceExclTax,
-                    'final_option_price' => $selectionPrice,
-                    'final_option_price_excl_tax' => $selectionPriceExclTax
+                    'regular_option_price' => $this->priceCurrency->convert($regularPrice),
+                    'regular_option_price_excl_tax' => $this->priceCurrency->convert($regularPriceExclTax),
+                    'final_option_price' => $this->priceCurrency->convert($selectionPrice),
+                    'final_option_price_excl_tax' => $this->priceCurrency->convert($selectionPriceExclTax)
                 ];
             }
 

--- a/src/Model/Resolver/Product/BundleProductOptions.php
+++ b/src/Model/Resolver/Product/BundleProductOptions.php
@@ -85,7 +85,7 @@ class BundleProductOptions implements ResolverInterface
                 $taxableItem = $bundleProduct->getPriceType() == Price::PRICE_TYPE_FIXED ? $bundleProduct : $optionSelection;
 
                 $selectionPrice = $priceModel->getSelectionPrice($bundleProduct, $optionSelection, 1);
-                $selectionPriceExclTax = $this->catalogData->getTaxPrice($taxableItem, $selectionPrice, false);
+                $selectionPriceExclTax = $this->catalogData->getTaxPrice($taxableItem, $selectionPrice, false, null, null, null, null, null, false);
 
                 $selectionPriceType = $this->enumLookup->getEnumValueFromField(
                     'PriceTypeEnum',

--- a/src/Model/Resolver/Product/PriceRange.php
+++ b/src/Model/Resolver/Product/PriceRange.php
@@ -14,6 +14,7 @@ use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Pricing\SaleableInterface;
+use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Store\Api\Data\StoreInterface;
 use Magento\CatalogGraphQl\Model\Resolver\Product\PriceRange as CorePriceRange;
 
@@ -33,12 +34,18 @@ class PriceRange extends CorePriceRange
     protected $priceProviderPool;
 
     /**
+     * @var PriceCurrencyInterface
+     */
+    private PriceCurrencyInterface $priceCurrency;
+
+    /**
      * @param PriceProviderPool $priceProviderPool
      * @param Discount $discount
      */
     public function __construct(
         PriceProviderPool $priceProviderPool,
-        Discount $discount
+        Discount $discount,
+        PriceCurrencyInterface $priceCurrency
     )
     {
         parent::__construct(
@@ -48,6 +55,7 @@ class PriceRange extends CorePriceRange
 
         $this->priceProviderPool = $priceProviderPool;
         $this->discount = $discount;
+        $this->priceCurrency = $priceCurrency;
     }
 
     /**
@@ -95,7 +103,7 @@ class PriceRange extends CorePriceRange
         $regularPrice = (float) $priceProvider->getMinimalRegularPrice($product)->getValue();
         $finalPrice = (float) $priceProvider->getMinimalFinalPrice($product)->getValue();
 
-        $defaultRegularPrice = (float) $product->getPrice();
+        $defaultRegularPrice = $this->priceCurrency->convert($product->getPrice());
         $defaultFinalPrice = (float) $priceProvider->getRegularPrice($product)->getValue();
 
         $discount = $this->calculateDiscount($product, $regularPrice, $finalPrice);

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -141,19 +141,19 @@ extend type CustomizableCheckboxValue {
 }
 
 extend type BundleProduct {
-bundle_options: [BundleOption] @doc(description: "Additional pricing info specific for bundle products") @resolver(class: "ScandiPWA\\CatalogGraphQl\\Model\\Resolver\\Product\\BundleProductOptions")
+    bundle_options: [BundleOption] @doc(description: "Additional pricing info specific for bundle products") @resolver(class: "ScandiPWA\\CatalogGraphQl\\Model\\Resolver\\Product\\BundleProductOptions")
 }
 
 type BundleOption {
-option_id: Int
-selection_details: [BundleOptionSelection]
+    option_id: Int
+    selection_details: [BundleOptionSelection]
 }
 
 type BundleOptionSelection {
-selection_id: Int
-name: String
-regular_option_price: Float
-regular_option_price_excl_tax: Float
-final_option_price: Float
-final_option_price_excl_tax: Float
+    selection_id: Int
+    name: String
+    regular_option_price: Float
+    regular_option_price_excl_tax: Float
+    final_option_price: Float
+    final_option_price_excl_tax: Float
 }

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -24,6 +24,7 @@ input ProductAttributeFilterInput {
 type MediaGalleryEntry  @doc(description: "MediaGalleryEntry defines characteristics about images and videos associated with a specific product") {
     thumbnail: MediaGalleryImageOfType @doc(description: "The path of the thumbnail image on the server thumbnail")
     base: MediaGalleryImageOfType @doc(description: "The path of the thumbnail image on the server thumbnail")
+    large: MediaGalleryImageOfType @doc(description: "The path of the large image on the server")
 }
 
 type ProductImage @doc(description: "Extend product Image fields for frontend-driven loading mechanism") {
@@ -105,4 +106,22 @@ type DownloadableProduct {
 
 type DownloadableProductLinks {
     sample_url: String @resolver(class: "ScandiPWA\\CatalogGraphQl\\Model\\Resolver\\Product\\SampleUrl")
+}
+
+extend type BundleProduct {
+    bundle_options: [BundleOption] @doc(description: "Additional pricing info specific for bundle products") @resolver(class: "ScandiPWA\\CatalogGraphQl\\Model\\Resolver\\Product\\BundleProductOptions")
+}
+
+type BundleOption {
+    option_id: Int
+    selection_details: [BundleOptionSelection]
+}
+
+type BundleOptionSelection {
+    selection_id: Int
+    name: String
+    regular_option_price: Float
+    regular_option_price_excl_tax: Float
+    final_option_price: Float
+    final_option_price_excl_tax: Float
 }


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/1476

FE PR: https://github.com/scandipwa/scandipwa/pull/2602

**What was done:**
Main purpose of this PR was to calculate missing Fixed option price excl. tax.

Yet as part of it I also added logic for calculating price of the bundle product options of all option types (dynamic, fixed and percent). I decided to do this on the backend because FE logic became too hard to understand: bundle products are more complex than simple ones and  a lot of code has to be written to cover all the edge cases. What is also a bad point, it requires lots of calculations to be performed on FE, e.g. take regular price and multiply it by discount to get a final price. And calculation method differ a lot between option types, which results in many lines of code and a lot of conditional logic.

At the same time, magento already has methods for calculating all this, which are used by Luma itself, so I reused them. FE code has been simplified (see https://github.com/scandipwa/scandipwa/pull/2482/files). My tests showed that final price, regular price and taxes are calculated properly with this approach (tested against Luma). 

**Tech limitations and why GQL schema has such a structure:**

I added new field `bundle_options` to `BundleProduct` schema. First I tried to add new fields to `BundleItemOption` though. In theory, this should be as simple as injecting `ProductRepositoryInterface` or `ProductFactory` and using it to retrieve bundle product to perform calculations. And it did work: I was able to retrieve my new fields when testing the solution via graphql client (Altair).

But exactly same graphql query didn't work via ScandiPWA theme. Root cause is magento bug https://github.com/magento/magento2/issues/12278. Our `scandipwa/cache` module defines observer for event `catalog_product_collection_load_after` affected by this bug  ([link](https://github.com/scandipwa/cache/blob/f0b363d160b478016f333c113dd36eaa90840fa2/src/etc/events.xml#L24) to code). I was able to workaround this locally by commenting this observer (lines 24-26), but it will affect how caching works and is definitely not an option.