### PR TITLE
Add variants field modification optimized for PLP

### DIFF
--- a/src/Model/Resolver/ConfigurableVariantPlp.php
+++ b/src/Model/Resolver/ConfigurableVariantPlp.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Alfreds Genkins <info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
+ */
+
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver;
+
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\ResourceModel\Product\Attribute\CollectionFactory;
+use Magento\CatalogGraphQl\Model\Resolver\Products\Attributes\Collection as AttributeCollection;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable as Type;
+use Magento\ConfigurableProductGraphQl\Model\Options\Collection as OptionCollection;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\EntityManager\MetadataPool;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Query\Resolver\ValueFactory;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Store\Model\StoreManagerInterface;
+use ScandiPWA\CatalogGraphQl\Model\Variant\Collection;
+use ScandiPWA\Performance\Model\Resolver\ResolveInfoFieldsTrait;
+use ScandiPWA\Performance\Model\Resolver\Products\DataPostProcessor;
+
+/**
+ * Class ConfigurableVariantPlp
+ *
+ * @package ScandiPWA\CatalogGraphQl\Model\Resolver
+ */
+class ConfigurableVariantPlp extends ConfigurableVariant
+{
+    /**
+     * ConfigurableVariantPlp constructor.
+     *
+     * @param Collection $variantCollection
+     * @param OptionCollection $optionCollection
+     * @param ValueFactory $valueFactory
+     * @param AttributeCollection $attributeCollection
+     * @param MetadataPool $metadataPool
+     * @param CollectionFactory $collectionFactory
+     * @param StoreManagerInterface $storeManager
+     * @param DataPostProcessor $productPostProcessor
+     */
+    public function __construct(
+        Collection $variantCollection,
+        OptionCollection $optionCollection,
+        ValueFactory $valueFactory,
+        AttributeCollection $attributeCollection,
+        MetadataPool $metadataPool,
+        CollectionFactory $collectionFactory,
+        StoreManagerInterface $storeManager,
+        DataPostProcessor $productPostProcessor
+    ) {
+        parent::__construct(
+            $variantCollection,
+            $optionCollection,
+            $valueFactory,
+            $attributeCollection,
+            $metadataPool,
+            $collectionFactory,
+            $storeManager,
+            $productPostProcessor
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        $linkField = $this->metadataPool->getMetadata(ProductInterface::class)->getLinkField();
+
+        if ($value['type_id'] !== Type::TYPE_CODE || !isset($value[$linkField])) {
+            $result = function () {
+                return null;
+            };
+
+            return $this->valueFactory->create($result);
+        }
+
+        /** @var $searchCriteria SearchCriteriaInterface */
+        $searchCriteria = $context->getExtensionAttributes()->getSearchCriteria('search_criteria');
+
+        if ($searchCriteria) {
+            $this->variantCollection->setSearchCriteria($searchCriteria);
+        }
+
+        // Configure variant collection
+        $this->variantCollection->addParentProduct($value['model']);
+        $fields = $this->getFieldsFromProductInfo($info, 'variants/product');
+        $this->variantCollection->addEavAttributes($fields);
+
+        $result = function () use ($value, $linkField, $info) {
+            $products = $this->variantCollection->getChildProductsByParentIdPlp(
+                (int) $value[$linkField],
+                $info
+            );
+
+            return $products;
+        };
+
+        return $this->valueFactory->create($result);
+    }
+}

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -136,3 +136,7 @@ extend type CustomizableRadioValue {
 extend type CustomizableCheckboxValue {
     currency: String @doc(description: "Currency code for the option.")
 }
+
+extend type ConfigurableProduct {
+    variants_plp: [ConfigurableVariant] @doc(description: "An array of variants of products, optimized version for PLP") @resolver(class: "ScandiPWA\\CatalogGraphQl\\Model\\Resolver\\ConfigurableVariantPlp")
+}


### PR DESCRIPTION
For new PLP design we need to have all variants returned for all configurable products. It's possible to just fetch this field on PLP like we do on PDP, but it probably will have too bad impact on performance.

In this PR I added new `variants_plp` field which returns less data for variants (only basic fields + attributes) and for attributes I don't fetch all sub fields as well. Also, having separate field for PLP makes further performance optimizations less risky, because we'll be sure that changes don't affect PDP.

Frontend will request this new field on category and search results pages, related PR: https://github.com/IvansZuks/scandipwa/pull/6