### PR TITLE
Bugfix/2674/incorrect prices

### DIFF
--- a/src/Model/Resolver/Product/BundleProductOptions.php
+++ b/src/Model/Resolver/Product/BundleProductOptions.php
@@ -92,7 +92,12 @@ class BundleProductOptions implements ResolverInterface
                 $taxableItem = $bundleProduct->getPriceType() == Price::PRICE_TYPE_FIXED ? $bundleProduct : $optionSelection;
 
                 $selectionPrice = $priceModel->getSelectionPrice($bundleProduct, $optionSelection, 1);
-                $selectionPriceExclTax = $this->catalogData->getTaxPrice($taxableItem, $selectionPrice, false, null, null, null, null, null, false);
+                $selectionPriceInclTax = $this->catalogData->getTaxPrice(
+                    $taxableItem, $selectionPrice, true, null, null, null, null, null, false
+                );
+                $selectionPriceExclTax = $this->catalogData->getTaxPrice(
+                    $taxableItem, $selectionPrice, false, null, null, null, null, null, false
+                );
 
                 $selectionPriceType = $this->enumLookup->getEnumValueFromField(
                     'PriceTypeEnum',
@@ -105,13 +110,14 @@ class BundleProductOptions implements ResolverInterface
                         : $optionSelection->getSelectionPriceValue()
                     : $optionSelection->getPrice();
 
+                $regularPriceInclTax = $this->catalogData->getTaxPrice($taxableItem, $regularPrice, true);
                 $regularPriceExclTax = $this->catalogData->getTaxPrice($taxableItem, $regularPrice, false);
 
                 $selectionsResult[] = [
                     'selection_id' => $optionSelection->getSelectionId(),
-                    'regular_option_price' => $this->priceCurrency->convert($regularPrice),
+                    'regular_option_price' => $this->priceCurrency->convert($regularPriceInclTax),
                     'regular_option_price_excl_tax' => $this->priceCurrency->convert($regularPriceExclTax),
-                    'final_option_price' => $this->priceCurrency->convert($selectionPrice),
+                    'final_option_price' => $this->priceCurrency->convert($selectionPriceInclTax),
                     'final_option_price_excl_tax' => $this->priceCurrency->convert($selectionPriceExclTax)
                 ];
             }

--- a/src/Model/Resolver/Product/PriceRange.php
+++ b/src/Model/Resolver/Product/PriceRange.php
@@ -9,9 +9,14 @@ namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Product;
 
 use Magento\CatalogGraphQl\Model\Resolver\Product\Price\Discount;
 use Magento\CatalogGraphQl\Model\Resolver\Product\Price\ProviderPool as PriceProviderPool;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Catalog\Helper\Data as TaxHelper;
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Type as ProductType;
+use Magento\Catalog\Pricing\Price\FinalPrice;
+use Magento\Catalog\Pricing\Price\RegularPrice;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Pricing\SaleableInterface;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
@@ -23,6 +28,8 @@ use Magento\CatalogGraphQl\Model\Resolver\Product\PriceRange as CorePriceRange;
  */
 class PriceRange extends CorePriceRange
 {
+    const XML_PRICE_INCLUDES_TAX = 'tax/calculation/price_includes_tax';
+
     /**
      * @var Discount
      */
@@ -39,13 +46,25 @@ class PriceRange extends CorePriceRange
     private PriceCurrencyInterface $priceCurrency;
 
     /**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     * @var TaxHelper
+     */
+    protected $taxHelper;
+
+    /**
      * @param PriceProviderPool $priceProviderPool
      * @param Discount $discount
      */
     public function __construct(
         PriceProviderPool $priceProviderPool,
         Discount $discount,
-        PriceCurrencyInterface $priceCurrency
+        PriceCurrencyInterface $priceCurrency,
+        ScopeConfigInterface $scopeConfig,
+        TaxHelper $taxHelper
     )
     {
         parent::__construct(
@@ -56,6 +75,8 @@ class PriceRange extends CorePriceRange
         $this->priceProviderPool = $priceProviderPool;
         $this->discount = $discount;
         $this->priceCurrency = $priceCurrency;
+        $this->scopeConfig = $scopeConfig;
+        $this->taxHelper = $taxHelper;
     }
 
     /**
@@ -103,14 +124,23 @@ class PriceRange extends CorePriceRange
         $regularPrice = (float) $priceProvider->getMinimalRegularPrice($product)->getValue();
         $finalPrice = (float) $priceProvider->getMinimalFinalPrice($product)->getValue();
 
-        $defaultRegularPrice = $this->priceCurrency->convert($product->getPrice());
-        $defaultFinalPrice = (float) $priceProvider->getRegularPrice($product)->getValue();
-
         $discount = $this->calculateDiscount($product, $regularPrice, $finalPrice);
 
         $regularPriceExclTax = (float) $priceProvider->getMinimalRegularPrice($product)->getBaseAmount();
         $finalPriceExclTax = (float) $priceProvider->getMinimalFinalPrice($product)->getBaseAmount();
-        $defaultFinalPriceExclTax = (float) $priceProvider->getRegularPrice($product)->getBaseAmount();
+
+        if($product->getTypeId() == ProductType::TYPE_SIMPLE) {
+            $priceInfo = $product->getPriceInfo();
+            $defaultRegularPrice = $priceInfo->getPrice(RegularPrice::PRICE_CODE)->getAmount()->getValue();
+            $defaultFinalPrice = $priceInfo->getPrice(FinalPrice::PRICE_CODE)->getAmount()->getValue();
+            $defaultFinalPriceExclTax = $priceInfo->getPrice(FinalPrice::PRICE_CODE)->getAmount()->getBaseAmount();
+
+            $discount = $this->calculateDiscount($product, $defaultRegularPrice, $defaultFinalPrice);
+        } else {
+            $defaultRegularPrice = $this->taxHelper->getTaxPrice($product, $product->getPrice(), $this->isPriceIncludesTax());
+            $defaultFinalPrice = (float) round($priceProvider->getRegularPrice($product)->getValue(), 2);
+            $defaultFinalPriceExclTax = (float) $priceProvider->getRegularPrice($product)->getBaseAmount();
+        }
 
         $minPriceArray = $this->formatPrice(
             $regularPrice, $regularPriceExclTax, $finalPrice, $finalPriceExclTax,
@@ -248,5 +278,12 @@ class PriceRange extends CorePriceRange
         $now = time();
 
         return ($now >= $from && $now <= $to) || ($now >= $from && is_null($to)) ? (float)$specialPrice : null;
+    }
+
+    protected function isPriceIncludesTax(){
+        return $this->scopeConfig->getValue(
+            self::XML_PRICE_INCLUDES_TAX,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORES
+        );
     }
 }

--- a/src/Model/Resolver/Product/PriceRange.php
+++ b/src/Model/Resolver/Product/PriceRange.php
@@ -142,6 +142,10 @@ class PriceRange extends CorePriceRange
             $defaultFinalPriceExclTax = (float) $priceProvider->getRegularPrice($product)->getBaseAmount();
         }
 
+        $defaultRegularPrice = isset($defaultRegularPrice) ? $defaultRegularPrice : 0;
+        $defaultFinalPrice = isset($defaultFinalPrice) ? $defaultFinalPrice : 0;
+        $defaultFinalPriceExclTax = isset($defaultFinalPriceExclTax) ? $defaultFinalPriceExclTax : 0;
+
         $minPriceArray = $this->formatPrice(
             $regularPrice, $regularPriceExclTax, $finalPrice, $finalPriceExclTax,
             $defaultRegularPrice, $defaultFinalPrice, $defaultFinalPriceExclTax, $discount, $store

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -115,34 +115,50 @@ type DownloadableProductLinks {
 
 extend type CustomizableAreaValue {
     currency: String @doc(description: "Currency code for the option.")
+    priceInclTax: Float @doc(description: "Option value price including tax.")
+    priceExclTax: Float @doc(description: "Option value price excluding tax.")
 }
 
 extend type CustomizableDateValue {
     currency: String @doc(description: "Currency code for the option.")
+    priceInclTax: Float @doc(description: "Option value price including tax.")
+    priceExclTax: Float @doc(description: "Option value price excluding tax.")
 }
 
 extend type CustomizableDropDownValue {
     currency: String @doc(description: "Currency code for the option.")
+    priceInclTax: Float @doc(description: "Option value price including tax.")
+    priceExclTax: Float @doc(description: "Option value price excluding tax.")
 }
 
 extend type CustomizableMultipleValue {
     currency: String @doc(description: "Currency code for the option.")
+    priceInclTax: Float @doc(description: "Option value price including tax.")
+    priceExclTax: Float @doc(description: "Option value price excluding tax.")
 }
 
 extend type CustomizableFieldValue {
     currency: String @doc(description: "Currency code for the option.")
+    priceInclTax: Float @doc(description: "Option value price including tax.")
+    priceExclTax: Float @doc(description: "Option value price excluding tax.")
 }
 
 extend type CustomizableFileValue {
     currency: String @doc(description: "Currency code for the option.")
+    priceInclTax: Float @doc(description: "Option value price including tax.")
+    priceExclTax: Float @doc(description: "Option value price excluding tax.")
 }
 
 extend type CustomizableRadioValue {
     currency: String @doc(description: "Currency code for the option.")
+    priceInclTax: Float @doc(description: "Option value price including tax.")
+    priceExclTax: Float @doc(description: "Option value price excluding tax.")
 }
 
 extend type CustomizableCheckboxValue {
     currency: String @doc(description: "Currency code for the option.")
+    priceInclTax: Float @doc(description: "Option value price including tax.")
+    priceExclTax: Float @doc(description: "Option value price excluding tax.")
 }
 
 extend type BundleProduct {


### PR DESCRIPTION
Issue: https://github.com/scandipwa/scandipwa/issues/2674

- Add calculaltion of options prices with and without tax
- add calcualtion of simple product price initial price (i.e. when none of the options is selected). the value we showed before was incorrect, as it showed min price of product, when least expensive required options are selected. 

FE PR: https://github.com/scandipwa/scandipwa/pull/2807