### PR TITLE
Bundle label fix for 2.4.3

### DIFF
--- a/src/Model/Resolver/Product/BundleLabel.php
+++ b/src/Model/Resolver/Product/BundleLabel.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Viktors Pliska <info@scandiweb.com>
+ * @copyright   Copyright (c) 2018 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Product;
+
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\BundleGraphQl\Model\Resolver\Options\Label;
+
+class BundleLabel extends Label
+{
+    /**
+     * @param Field $field
+     * @param ContextInterface $context
+     * @param ResolveInfo $info
+     * @param array|null $value
+     * @param array|null $args
+     * @return \Magento\Framework\GraphQl\Query\Resolver\Value|mixed
+     * @throws \Exception
+     */
+    public function resolve(Field $field, $context, ResolveInfo $info, array $value = null, array $args = null)
+    {
+        if (isset($value['product']) && isset($value['product']['name'])) {
+            return $value['product']['name'];
+        }
+
+        return parent::resolve($field, $context, $info, $value, $args);
+    }
+}

--- a/src/Model/Resolver/Product/BundleLabel.php
+++ b/src/Model/Resolver/Product/BundleLabel.php
@@ -4,7 +4,7 @@
  *
  * @category    ScandiPWA
  * @package     ScandiPWA_CatalogGraphQl
- * @author      Viktors Pliska <info@scandiweb.com>
+ * @author      <info@scandiweb.com>
  * @copyright   Copyright (c) 2018 Scandiweb, Ltd (https://scandiweb.com)
  */
 declare(strict_types=1);

--- a/src/etc/graphql/di.xml
+++ b/src/etc/graphql/di.xml
@@ -95,4 +95,7 @@
 
     <preference for="Magento\CatalogGraphQl\Model\Resolver\Category\DataProvider\Breadcrumbs"
                 type="ScandiPWA\CatalogGraphQl\Model\Resolver\Category\DataProvider\Breadcrumbs" />
+
+    <preference for="Magento\BundleGraphQl\Model\Resolver\Options\Label"
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Product\BundleLabel" />
 </config>


### PR DESCRIPTION
**Problem**
* Some products (not in stock, configurable variants) return label as null

**In this PR**
* Returns product name from model.