### PR TITLE
#3314 Categoy/Product url rewrite save patch

### DIFF
--- a/src/Model/ResourceModel/Category/Product.php
+++ b/src/Model/ResourceModel/Category/Product.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      scandiweb <info@scandiweb.com>
+ * @copyright   Copyright (c) 2019 Scandiweb, Ltd (https://scandiweb.com)
+ */
+
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\ResourceModel\Category;
+
+use Magento\CatalogUrlRewrite\Model\ResourceModel\Category\Product as SourceProduct;
+
+class Product extends SourceProduct
+{
+    const DUPLICATE_FIELDS = ['url_rewrite_id', 'category_id', 'product_id'];
+
+    /**
+     * Save multiple data
+     *
+     * @param array $insertData
+     * @return int
+     */
+    public function saveMultiple(array $insertData)
+    {
+        $connection = $this->getConnection();
+        if (count($insertData) <= self::CHUNK_SIZE) {
+            return $connection->insertOnDuplicate($this->getTable(self::TABLE_NAME), $insertData, self::DUPLICATE_FIELDS);
+        }
+        $data = array_chunk($insertData, self::CHUNK_SIZE);
+        $totalCount = 0;
+        foreach ($data as $insertData) {
+            $totalCount += $connection->insertOnDuplicate($this->getTable(self::TABLE_NAME), $insertData, self::DUPLICATE_FIELDS);
+        }
+        return $totalCount;
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -88,4 +88,7 @@
 
     <preference for="Magento\CatalogGraphQl\Model\Resolver\Product\Options"
                 type="ScandiPWA\CatalogGraphQl\Model\Resolver\Product\Options" />
+
+    <preference for="Magento\CatalogUrlRewrite\Model\ResourceModel\Category\Product"
+                type="ScandiPWA\CatalogGraphQl\Model\ResourceModel\Category\Product" />
 </config>


### PR DESCRIPTION
**Original issue:**
* https://github.com/scandipwa/scandipwa/issues/3314

**Problem**
* Magento uses insert query when updating/inserting url rewrite links, thus if insert already exists it throws error. (M.2.4.3 added constraint for table `catalog_url_rewrite_product_category`, that causes this issue)

**In this PR:**
* Updated insert for table `catalog_url_rewrite_product_category` to use `insertOnDuplicate`