### PR TITLE
Performance optimizations

### DIFF
--- a/src/Model/Resolver/Products/DataProvider/Product/CollectionProcessor/AttributeProcessor.php
+++ b/src/Model/Resolver/Products/DataProvider/Product/CollectionProcessor/AttributeProcessor.php
@@ -30,8 +30,18 @@ class AttributeProcessor implements CollectionProcessorInterface
         array $attributeNames,
         ContextInterface $context = null
     ): Collection {
-        // this simply works faster then adding one-by-one as each addAttributeToSelect makes a request to MYSQL
-        $collection->addAttributeToSelect('*');
+        // returning individual addAttributeToSelect calls
+        // while each of these runs a mysql query
+        // it is still faster than adding all attributes to select
+        // since that adds default+store-specific joins for each attribute in collection afterLoad
+        // previous addAttibuteToSelect('*') simply transferred the bulk of load to a different point in time
+        foreach ($attributeNames as $name) {
+            if ($name !== self::ATTRIBUTES_FIELD) {
+                $collection->addAttributeToSelect($name);
+
+                continue;
+            }
+        }
 
         return $collection;
     }

--- a/src/Model/Resolver/Products/DataProvider/Product/CollectionProcessor/AttributeProcessor.php
+++ b/src/Model/Resolver/Products/DataProvider/Product/CollectionProcessor/AttributeProcessor.php
@@ -38,8 +38,6 @@ class AttributeProcessor implements CollectionProcessorInterface
         foreach ($attributeNames as $name) {
             if ($name !== self::ATTRIBUTES_FIELD) {
                 $collection->addAttributeToSelect($name);
-
-                continue;
             }
         }
 

--- a/src/Model/Resolver/Products/DataProvider/Product/CriteriaCheck.php
+++ b/src/Model/Resolver/Products/DataProvider/Product/CriteriaCheck.php
@@ -1,11 +1,20 @@
 <?php
-
+/**
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @copyright   Copyright (c) 2021 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare(strict_types=1);
 
 namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product;
 
-
+use Magento\Framework\Api\Filter;
 use Magento\Framework\Api\SearchCriteriaInterface;
 
+/**
+ * Class CriteriaCheck
+ * @package ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product
+ */
 class CriteriaCheck
 {
     /**
@@ -28,7 +37,34 @@ class CriteriaCheck
     }
 
     /**
-     * @param \Magento\Framework\Api\Filter $filter
+     * @param SearchCriteriaInterface $searchCriteria
+     * @return bool
+     */
+    static public function isOnlySingleIdFilter(SearchCriteriaInterface $searchCriteria): bool
+    {
+        foreach ($searchCriteria->getFilterGroups() as $filterGroup) {
+            $filters = $filterGroup->getFilters();
+
+            foreach ($filters as $filter) {
+                $type = $filter->getConditionType();
+                $field = $filter->getField();
+
+                // skippable filters that are always present
+                if (in_array($field, ['customer_group_id', 'visibility'])) {
+                    continue;
+                }
+
+                if ($type !== 'eq' || $field !== 'id') {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param Filter $filter
      * @return bool
      */
     static public function isSingleProductFilterType($filter) {

--- a/src/Model/Resolver/Products/DataProvider/Product/EmulateSearchResult.php
+++ b/src/Model/Resolver/Products/DataProvider/Product/EmulateSearchResult.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @copyright   Copyright (c) 2021 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product;
+
+use Magento\Framework\Api\AttributeValueFactory;
+use Magento\Framework\Api\Search\DocumentFactory;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\Search\SearchResultInterface;
+use Magento\Framework\Api\Search\SearchResultFactory as FrameworkSearchResultFactory;
+
+/**
+ * Class EmulateSearchResult
+ * @package ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\Product
+ */
+class EmulateSearchResult
+{
+    /**
+     * @var AttributeValueFactory
+     */
+    protected $attributeValueFactory;
+
+    /**
+     * @var DocumentFactory
+     */
+    protected $documentFactory;
+
+    /**
+     * @var FrameworkSearchResultFactory
+     */
+    protected $frameworkSearchResultFactory;
+
+    /**
+     * EmulateSearchResult constructor.
+     * @param AttributeValueFactory $attributeValueFactory
+     * @param DocumentFactory $documentFactory
+     * @param FrameworkSearchResultFactory $frameworkSearchResultFactory
+     */
+    public function __construct(
+        AttributeValueFactory $attributeValueFactory,
+        DocumentFactory $documentFactory,
+        FrameworkSearchResultFactory $frameworkSearchResultFactory
+    ) {
+        $this->attributeValueFactory = $attributeValueFactory;
+        $this->documentFactory = $documentFactory;
+        $this->frameworkSearchResultFactory = $frameworkSearchResultFactory;
+    }
+
+    /**
+     * Emulates ES search repsonse for specific ID query
+     * @param SearchCriteriaInterface $searchCriteria
+     * @return SearchResultInterface
+     */
+    public function execute(SearchCriteriaInterface $searchCriteria): SearchResultInterface
+    {
+        $idFilterValue = self::getIdFilterValue($searchCriteria);
+
+        $scoreAttribute = $this->attributeValueFactory->create();
+        $scoreAttribute->setAttributeCode('_score');
+        $scoreAttribute->setValue(null);
+
+        $document = $this->documentFactory->create();
+        $document->setId($idFilterValue);
+        $document->setCustomAttribute('score', $scoreAttribute);
+
+        /** @var SearchResultInterface $itemsResults */
+        $itemsResults = $this->frameworkSearchResultFactory->create();
+        $itemsResults->setItems([$document]);
+        $itemsResults->setTotalCount(1);
+        $itemsResults->setSearchCriteria($searchCriteria);
+
+        return $itemsResults;
+    }
+
+    /**
+     * @param SearchCriteriaInterface $searchCriteria
+     * @return int|null
+     */
+    static public function getIdFilterValue(SearchCriteriaInterface $searchCriteria)
+    {
+        foreach ($searchCriteria->getFilterGroups() as $filterGroup) {
+            $filters = $filterGroup->getFilters();
+
+            foreach ($filters as $filter) {
+                $type = $filter->getConditionType();
+                $field = $filter->getField();
+
+                if ($type === 'eq' && $field === 'id') {
+                    return $filter->getValue();
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Model/Resolver/Products/DataProvider/ProductSearch/ProductCollectionSearchCriteriaBuilder.php
+++ b/src/Model/Resolver/Products/DataProvider/ProductSearch/ProductCollectionSearchCriteriaBuilder.php
@@ -14,6 +14,10 @@ use Magento\Framework\Api\Search\SearchCriteriaInterfaceFactory;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\ProductSearch\ProductCollectionSearchCriteriaBuilder as CoreProductCollectionSearchCriteriaBuilder;
 
+/**
+ * Class ProductCollectionSearchCriteriaBuilder
+ * @package ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\ProductSearch
+ */
 class ProductCollectionSearchCriteriaBuilder extends  CoreProductCollectionSearchCriteriaBuilder
 {
     /**

--- a/src/Model/Resolver/Products/DataProvider/ProductSearch/ProductCollectionSearchCriteriaBuilder.php
+++ b/src/Model/Resolver/Products/DataProvider/ProductSearch/ProductCollectionSearchCriteriaBuilder.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @copyright   Copyright (c) 2021 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\ProductSearch;
+
+use Magento\Framework\Api\FilterBuilder;
+use Magento\Framework\Api\Search\FilterGroupBuilder;
+use Magento\Framework\Api\Search\SearchCriteriaInterfaceFactory;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\ProductSearch\ProductCollectionSearchCriteriaBuilder as CoreProductCollectionSearchCriteriaBuilder;
+
+class ProductCollectionSearchCriteriaBuilder extends  CoreProductCollectionSearchCriteriaBuilder
+{
+    /**
+     * @var SearchCriteriaInterfaceFactory
+     */
+    protected $searchCriteriaFactory;
+
+    /**
+     * @var FilterBuilder
+     */
+    protected $filterBuilder;
+
+    /**
+     * @var FilterGroupBuilder
+     */
+    protected $filterGroupBuilder;
+
+    /**
+     * @param SearchCriteriaInterfaceFactory $searchCriteriaFactory
+     * @param FilterBuilder $filterBuilder
+     * @param FilterGroupBuilder $filterGroupBuilder
+     */
+    public function __construct(
+        SearchCriteriaInterfaceFactory $searchCriteriaFactory,
+        FilterBuilder $filterBuilder,
+        FilterGroupBuilder $filterGroupBuilder
+    ) {
+        $this->searchCriteriaFactory = $searchCriteriaFactory;
+        $this->filterBuilder = $filterBuilder;
+        $this->filterGroupBuilder = $filterGroupBuilder;
+    }
+
+    /**
+     * Build searchCriteria from search for product collection
+     * Rewrite: removed addition of category filter, as ES search query already applies that filter
+     *
+     * @param SearchCriteriaInterface $searchCriteria
+     * @return SearchCriteriaInterface
+     */
+    public function build(SearchCriteriaInterface $searchCriteria): SearchCriteriaInterface
+    {
+        //Create a copy of search criteria without filters to preserve the results from search
+        $searchCriteriaForCollection = $this->searchCriteriaFactory->create()
+            ->setSortOrders($searchCriteria->getSortOrders())
+            ->setPageSize($searchCriteria->getPageSize())
+            ->setCurrentPage($searchCriteria->getCurrentPage());
+
+        return $searchCriteriaForCollection;
+    }
+}

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -28,6 +28,9 @@
     <preference for="Magento\CatalogWidget\Model\Rule\Condition\Product"
                 type="ScandiPWA\CatalogGraphQl\Model\Rule\Condition\Product" />
 
+    <preference for="Magento\CatalogGraphQl\Model\Resolver\Products\DataProvider\ProductSearch\ProductCollectionSearchCriteriaBuilder"
+                type="ScandiPWA\CatalogGraphQl\Model\Resolver\Products\DataProvider\ProductSearch\ProductCollectionSearchCriteriaBuilder" />
+
     <!-- Performance related changes -->
     <preference for="Magento\ConfigurableProductGraphQl\Model\Resolver\ConfigurableVariant"
                 type="ScandiPWA\CatalogGraphQl\Model\Resolver\ConfigurableVariant" />

--- a/src/etc/schema.graphqls
+++ b/src/etc/schema.graphqls
@@ -19,6 +19,7 @@ input ProductAttributeFilterInput {
     customer_group_id: FilterTypeInput @doc(description: "Modifies product prices based on customer group")
     news_from_date: FilterTypeInput @doc(description: "The beginning date for new product listings, and determines if the product is featured as a new product.")
     news_to_date: FilterTypeInput @doc(description: "The end date for new product listings.")
+    id: FilterTypeInput @doc(description: "Entity id filter for products")
 }
 
 type MediaGalleryEntry  @doc(description: "MediaGalleryEntry defines characteristics about images and videos associated with a specific product") {

--- a/src/etc/search_request.xml
+++ b/src/etc/search_request.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * ScandiPWA - Progressive Web App for Magento
+ *
+ * Copyright © Scandiweb, Inc. All rights reserved.
+ * See LICENSE for license details.
+ *
+ * @license OSL-3.0 (Open Software License ("OSL") v. 3.0)
+ */
+-->
+<requests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:framework:Search/etc/search_request.xsd">
+    <!-- Request schema for product search excluding aggregation -->
+    <request query="graphql_product_search" index="catalogsearch_fulltext">
+        <queries>
+            <query xsi:type="boolQuery" name="graphql_product_search" boost="1">
+                <queryReference clause="must" ref="id"/>
+            </query>
+            <query name="id" xsi:type="filteredQuery">
+                <filterReference clause="must" ref="id_filter"/>
+            </query>
+        </queries>
+        <filters>
+            <filter xsi:type="termFilter" name="id_filter" field="_id" value="$id$"/>
+        </filters>
+    </request>
+</requests>


### PR DESCRIPTION
- Skipping item collection load for PLP filter query
- adding ES search by product id support
- disabling unnecessary ES query for single item loads
- removing unnecessary category filter(duplicate with ES filter)
- removing selection of all product attributes and bringing back attr selection on demand (attr post-processor still loads all the PLP/PDP attributes after a separate collection load)