### PR TITLE
[2666] Customizable option with discount / price rules

### DIFF
--- a/src/Model/Resolver/Product/Options.php
+++ b/src/Model/Resolver/Product/Options.php
@@ -23,6 +23,7 @@ use Magento\CatalogGraphQl\Model\Resolver\Product\Options as CoreOptions;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Query\Uid;
 use Magento\Framework\App\ObjectManager;
+use Magento\Catalog\Model\Product\Option\Value as OptionValue;
 use Magento\Catalog\Pricing\Price\CalculateCustomOptionCatalogRule;
 
 /**
@@ -31,7 +32,8 @@ use Magento\Catalog\Pricing\Price\CalculateCustomOptionCatalogRule;
 class Options extends CoreOptions
 {
     protected const OPTION_TYPE = 'custom-option';
-
+    protected const DYNAMIC_TYPE = 'DYNAMIC';
+    
     /**
      * @var PriceCurrencyInterface
      */
@@ -100,10 +102,10 @@ class Options extends CoreOptions
     public function updateOptionPriceData(array &$optionArray, $optionValue, $product, $currentCurrency) {
         $optionArray['price_type'] = $optionValue->getPriceType() !== null
             ? strtoupper($optionValue->getPriceType())
-            : 'DYNAMIC';
+            : self::DYNAMIC_TYPE;
         $optionArray['price'] = $this->getPrice(
             $optionArray['price'],
-            strtoupper($optionValue->getPriceType()) == 'PERCENT',
+            strtolower($optionValue->getPriceType()) == OptionValue::TYPE_PERCENT,
             $product
         );
 
@@ -111,7 +113,7 @@ class Options extends CoreOptions
         $optionArray['currency'] = $currentCurrency;
 
         // Calculate price including tax for option value
-        $taxablePrice = strtoupper($optionValue->getPriceType()) == 'PERCENT'
+        $taxablePrice = strtolower($optionValue->getPriceType()) == OptionValue::TYPE_PERCENT
             ? $product->getFinalPrice() * $selectionPrice / 100
             : $selectionPrice;
         $taxablePrice = $this->priceCurrency->convert($taxablePrice);

--- a/src/Model/Resolver/Product/Options.php
+++ b/src/Model/Resolver/Product/Options.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace ScandiPWA\CatalogGraphQl\Model\Resolver\Product;
 
+use Magento\Catalog\Pricing\Price\BasePrice;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
@@ -22,6 +23,7 @@ use Magento\CatalogGraphQl\Model\Resolver\Product\Options as CoreOptions;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Query\Uid;
 use Magento\Framework\App\ObjectManager;
+use Magento\Catalog\Pricing\Price\CalculateCustomOptionCatalogRule;
 
 /**
  * Format a product's option information to conform to GraphQL schema representation
@@ -44,20 +46,82 @@ class Options extends CoreOptions
     protected $uidEncoder;
 
     /**
+     * @var CalculateCustomOptionCatalogRule
+     */
+    protected $calculateCustomOptionCatalogRule;
+
+    /**
      * @param PriceCurrencyInterface $priceCurrency
      * @param CatalogData $catalogData
      * @param Uid|null $uidEncoder
+     * @param CalculateCustomOptionCatalogRule|null $calculateCustomOptionCatalogRule
      */
     public function __construct(
         PriceCurrencyInterface $priceCurrency,
         CatalogData $catalogData,
-        Uid $uidEncoder = null
+        Uid $uidEncoder = null,
+        CalculateCustomOptionCatalogRule $calculateCustomOptionCatalogRule
     )
     {
+        $this->calculateCustomOptionCatalogRule = $calculateCustomOptionCatalogRule;
         $this->priceCurrency = $priceCurrency;
         $this->catalogData = $catalogData;
         $this->uidEncoder = $uidEncoder ?: ObjectManager::getInstance()
             ->get(Uid::class);
+    }
+
+    /**
+     * @param $price
+     * @param $isPercent
+     * @param $product
+     * @return float
+     */
+    public function getPrice($price, $isPercent, $product)
+    {
+        $catalogPriceValue = $this->calculateCustomOptionCatalogRule->execute(
+            $product,
+            (float)$price,
+            $isPercent
+        );
+
+        if ($catalogPriceValue!==null) {
+            return $catalogPriceValue;
+        }
+
+        return $price;
+    }
+
+    /**
+     * @param array $optonArray
+     * @param $optionValue
+     * @param $product
+     * @param $currentCurrency
+     */
+    public function updateOptionPriceData(array &$optionArray, $optionValue, $product, $currentCurrency) {
+        $optionArray['price_type'] = $optionValue->getPriceType() !== null
+            ? strtoupper($optionValue->getPriceType())
+            : 'DYNAMIC';
+        $optionArray['price'] = $this->getPrice(
+            $optionArray['price'],
+            strtoupper($optionValue->getPriceType()) == 'PERCENT',
+            $product
+        );
+
+        $selectionPrice = $optionArray['price'];
+        $optionArray['currency'] = $currentCurrency;
+
+        // Calculate price including tax for option value
+        $taxablePrice = strtoupper($optionValue->getPriceType()) == 'PERCENT'
+            ? $product->getFinalPrice() * $selectionPrice / 100
+            : $selectionPrice;
+        $taxablePrice = $this->priceCurrency->convert($taxablePrice);
+
+        $optionArray['priceInclTax'] = $this->catalogData->getTaxPrice(
+            $product, $taxablePrice, true, null, null, null, null, null, null
+        );
+        $optionArray['priceExclTax'] = $this->catalogData->getTaxPrice(
+            $product, $taxablePrice, false, null, null, null, null, null, null
+        );
     }
 
     /**
@@ -106,48 +170,14 @@ class Options extends CoreOptions
                 /** @var Option\Value $optionValue */
                 foreach ($values as $valueKey => $optionValue) {
                     $options[$key]['value'][$valueKey] = $optionValue->getData();
-                    $options[$key]['value'][$valueKey]['price_type']
-                        = $optionValue->getPriceType() !== null ? strtoupper($optionValue->getPriceType()) : 'DYNAMIC';
-
-                    $selectionPrice = $options[$key]['value'][$valueKey]['price'];
-                    $options[$key]['value'][$valueKey]['price'] = $selectionPrice;
-                    $options[$key]['value'][$valueKey]['currency'] = $currentCurrency;
-
-                    // Calculate price including tax for option value
-                    $taxablePrice = strtoupper($optionValue->getPriceType()) == 'PERCENT'
-                        ? $product->getFinalPrice() * $selectionPrice / 100
-                        : $selectionPrice;
-                    $taxablePrice = $this->priceCurrency->convert($taxablePrice);
-
-                    $options[$key]['value'][$valueKey]['priceInclTax'] = $this->catalogData->getTaxPrice(
-                        $product, $taxablePrice, true, null, null, null, null, null, null
-                    );
-                    $options[$key]['value'][$valueKey]['priceExclTax'] = $this->catalogData->getTaxPrice(
-                        $product, $taxablePrice, false, null, null, null, null, null, null
+                    $this->updateOptionPriceData(
+                        $options[$key]['value'][$valueKey], $optionValue, $product, $currentCurrency
                     );
                 }
 
                 if (empty($values)) {
                     $options[$key]['value'] = $option->getData();
-                    $options[$key]['value']['price_type']
-                        = $option->getPriceType() !== null ? strtoupper($option->getPriceType()) : 'DYNAMIC';
-
-                    $selectionPrice = $options[$key]['value']['price'];
-                    $options[$key]['value']['price'] = $selectionPrice;
-                    $options[$key]['value']['currency'] = $currentCurrency;
-
-                    // Calculate price including tax for option value
-                    $taxablePrice = strtoupper($option->getPriceType()) == 'PERCENT'
-                        ? $product->getFinalPrice() * $selectionPrice / 100
-                        : $selectionPrice;
-                    $taxablePrice = $this->priceCurrency->convert($taxablePrice);
-
-                    $options[$key]['value']['priceInclTax'] = $this->catalogData->getTaxPrice(
-                        $product, $taxablePrice, true, null, null, null, null, null, null
-                    );
-                    $options[$key]['value']['priceExclTax'] = $this->catalogData->getTaxPrice(
-                        $product, $taxablePrice, false, null, null, null, null, null, null
-                    );
+                    $this->updateOptionPriceData($options[$key]['value'], $option, $product, $currentCurrency);
                 }
             }
         }


### PR DESCRIPTION
**Original issue:**
* Fixes https://github.com/scandipwa/scandipwa/issues/2666

**Problem:**
* Incorrect price object used for calculations when switching form base currency

**In this PR:**
* Added function `getPrice` that converts `[price]` correctly between non-base currency, by utilizing same principle as magento uses for price calculations in `Magento\Catalog\Model\Product\Option\Value` via `CalculateCustomOptionCatalogRule`
* Reduced repeated code by creating function `updateOptionPriceData`