### PR TITLE
[3655]Don't fetch disable variants on PLP

### DIFF
--- a/src/Model/Variant/Collection.php
+++ b/src/Model/Variant/Collection.php
@@ -452,6 +452,11 @@ class Collection
 
         /** @var Product $product */
         foreach ($products as $product) {
+            // Skip disabled products
+            if ($product->isDisabled()) {
+                continue;
+            }
+
             $productId = $product->getId();
             $productIds[] = $productId;
 


### PR DESCRIPTION
Original issues:
* Fixes https://github.com/scandipwa/scandipwa/issues/3655
* Fixes https://github.com/scandipwa/scandipwa/issues/3533

Problem:
* Graphql resolver ignores status for products, when fetching for PLP page

In this PR:
* Added check for variant status.