### PR TITLE
#3709 - fix am/pm date handling

### DIFF
--- a/src/Model/Product/Option/DateType.php
+++ b/src/Model/Product/Option/DateType.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * ScandiPWA_CatalogGraphQl
+ *
+ * @category    ScandiPWA
+ * @package     ScandiPWA_CatalogGraphQl
+ * @author      Alfreds Genkins <info@scandiweb.com>
+ * @copyright   Copyright (c) 2018 Scandiweb, Ltd (https://scandiweb.com)
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Model\Product\Option;
+
+use Magento\CatalogGraphQl\Model\Product\Option\DateType as SourceDateType;
+use Magento\Catalog\Model\Product\Option\Type\Date as ProductDateOptionType;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Stdlib\DateTime;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+
+/**
+ * @inheritdoc
+ */
+class DateType extends SourceDateType
+{
+    /**
+     * @inheritdoc
+     */
+    public function validateUserValue($values)
+    {
+        if ($this->_dateExists() || $this->_timeExists()) {
+            return parent::validateUserValue($this->formatValues($values));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Format date value from string to date array
+     *
+     * @param [] $values
+     * @return []
+     * @throws LocalizedException
+     */
+    protected function formatValues($values)
+    {
+        if (isset($values[$this->getOption()->getId()])) {
+            $value = $values[$this->getOption()->getId()];
+            if (isset($value['date']) || isset($value['day'], $value['month'], $value['year'])) {
+                return $values;
+            }
+            $dateTime = \DateTime::createFromFormat(DateTime::DATETIME_PHP_FORMAT, $value);
+
+            if ($dateTime === false) {
+                throw new GraphQlInputException(
+                    __('Invalid format provided. Please use \'Y-m-d H:i:s\' format.')
+                );
+            }
+
+            $values[$this->getOption()->getId()] = [
+                'date' => $value,
+                'year' => $dateTime->format('Y'),
+                'month' => $dateTime->format('m'),
+                'day' => $dateTime->format('d'),
+                'hour' => $dateTime->format('h'),
+                'minute' => $dateTime->format('i'),
+                'day_part' => $dateTime->format('a'),
+            ];
+        }
+
+        return $values;
+    }
+}

--- a/src/Model/Product/Option/Type/Date.php
+++ b/src/Model/Product/Option/Type/Date.php
@@ -9,10 +9,10 @@
  */
 declare(strict_types=1);
 
-namespace ScandiPWA\CatalogGraphQl\Model\Product\Option;
+namespace ScandiPWA\CatalogGraphQl\Model\Product\Option\Type;
 
-use Magento\CatalogGraphQl\Model\Product\Option\DateType as SourceDateType;
 use Magento\Catalog\Model\Product\Option\Type\Date as ProductDateOptionType;
+use Magento\CatalogGraphQl\Model\Product\Option\DateType as SourceDateType;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Stdlib\DateTime;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
@@ -20,7 +20,7 @@ use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 /**
  * @inheritdoc
  */
-class DateType extends SourceDateType
+class Date extends SourceDateType
 {
     /**
      * @inheritdoc
@@ -61,7 +61,9 @@ class DateType extends SourceDateType
                 'year' => $dateTime->format('Y'),
                 'month' => $dateTime->format('m'),
                 'day' => $dateTime->format('d'),
-                'hour' => $dateTime->format('h'),
+                'hour' => $this->is24hTimeFormat()
+                    ? $dateTime->format('H')
+                    : $dateTime->format('h'),
                 'minute' => $dateTime->format('i'),
                 'day_part' => $dateTime->format('a'),
             ];

--- a/src/etc/graphql/di.xml
+++ b/src/etc/graphql/di.xml
@@ -10,7 +10,9 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <preference for="Magento\Catalog\Model\Product\Option\Type\Date" type="ScandiPWA\CatalogGraphQl\Model\Product\Option\DateType" />
+    <preference for="Magento\Catalog\Model\Product\Option\Type\Date"
+                type="ScandiPWA\CatalogGraphQl\Model\Product\Option\Type\Date" />
+
     <type name="Magento\Framework\GraphQl\Query\Resolver\Argument\AstConverter">
         <plugin
             name="condition-applier-plugin"

--- a/src/etc/graphql/di.xml
+++ b/src/etc/graphql/di.xml
@@ -10,6 +10,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Magento\Catalog\Model\Product\Option\Type\Date" type="ScandiPWA\CatalogGraphQl\Model\Product\Option\DateType" />
     <type name="Magento\Framework\GraphQl\Query\Resolver\Argument\AstConverter">
         <plugin
             name="condition-applier-plugin"


### PR DESCRIPTION
**Issue:**
* Fixes https://github.com/scandipwa/scandipwa/issues/3709

**Problem:**
If we enter PM time (greater than 12) + `12h` time format is enabled, date transformations (before the record in DB is created) lead to data object with hours > 12 and `PM` setting stored in it. This object is used in later calculations and transformed to `next day, am hours`, which is inserted to `quote_item_option` table. It explains wrong time in cart. 

**Solution:**
Use `h` format instead of `H`, when creating object with date data
(1 letter in line 64 changed, the rest of the code copied from Magento catalog-graphql without changes (had to copy as target method was private)).