### PR TITLE
Passed the 6th param $includeDirectChildrenOnly class

### DIFF
--- a/src/Elasticsearch5/SearchAdapter/Aggregation/Interval.php
+++ b/src/Elasticsearch5/SearchAdapter/Aggregation/Interval.php
@@ -27,37 +27,37 @@ class Interval extends CoreInterval
     /**
      * @var ConnectionManager
      */
-    private $connectionManager;
+    protected $connectionManager;
 
     /**
      * @var FieldMapperInterface
      */
-    private $fieldMapper;
+    protected $fieldMapper;
 
     /**
      * @var Config
      */
-    private $clientConfig;
+    protected $clientConfig;
 
     /**
      * @var string
      */
-    private $fieldName;
+    protected $fieldName;
 
     /**
      * @var string
      */
-    private $storeId;
+    protected $storeId;
 
     /**
      * @var array
      */
-    private $entityIds;
+    protected $entityIds;
 
     /**
      * @var SearchIndexNameResolver
      */
-    private $searchIndexNameResolver;
+    protected $searchIndexNameResolver;
 
     /**
      * @param ConnectionManager $connectionManager
@@ -103,8 +103,8 @@ class Interval extends CoreInterval
     public function load($limit, $offset = null, $lower = null, $upper = null)
     {
 
-        $from = ['gte' => 0];
-        $to = ['lt' => 0];
+        $from = ['gte' => 0];       //Added this because in some situations the $lower is null and $from is not declared
+        $to = ['lt' => 0];          //Added this because in some situations the $data is null and $to is not declared
 
         if ($lower) {
             $from = ['gte' => $lower - self::DELTA];
@@ -137,8 +137,8 @@ class Interval extends CoreInterval
     public function loadPrevious($data, $index, $lower = null)
     {
 
-        $from = ['gte' => 0];
-        $to = ['lt' => 0];
+        $from = ['gte' => 0];       //Added this because in some situations the $lower is null and $from is not declared
+        $to = ['lt' => 0];          //Added this because in some situations the $data is null and $to is not declared
 
         if ($lower) {
             $from = ['gte' => $lower - self::DELTA];
@@ -176,7 +176,7 @@ class Interval extends CoreInterval
      *
      * @return float[]
      */
-    private function arrayValuesToFloat(array $hits, string $fieldName): array
+    protected function arrayValuesToFloat(array $hits, string $fieldName): array
     {
         $returnPrices = [];
         foreach ($hits as $hit) {
@@ -186,7 +186,6 @@ class Interval extends CoreInterval
         return $returnPrices;
     }
 
-
     /**
      * Prepare base query for search.
      *
@@ -194,7 +193,7 @@ class Interval extends CoreInterval
      * @param array|null $to
      * @return array
      */
-    private function prepareBaseRequestQuery($from = null, $to = null): array
+    protected function prepareBaseRequestQuery($from = null, $to = null): array
     {
         $requestQuery = [
             'index' => $this->searchIndexNameResolver->getIndexName($this->storeId, Fulltext::INDEXER_ID),
@@ -234,5 +233,4 @@ class Interval extends CoreInterval
 
         return $requestQuery;
     }
-
 }

--- a/src/Elasticsearch5/SearchAdapter/Aggregation/Interval.php
+++ b/src/Elasticsearch5/SearchAdapter/Aggregation/Interval.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace ScandiPWA\CatalogGraphQl\Elasticsearch5\SearchAdapter\Aggregation;
+
+use Magento\Elasticsearch\SearchAdapter\ConnectionManager;
+use Magento\Elasticsearch\Model\Adapter\FieldMapperInterface;
+use Magento\Elasticsearch\Model\Config;
+use Magento\Elasticsearch\SearchAdapter\SearchIndexNameResolver;
+use Magento\CatalogSearch\Model\Indexer\Fulltext;
+use Magento\Elasticsearch\Elasticsearch5\SearchAdapter\Aggregation\Interval as CoreInterval;
+
+/**
+ * Aggregate price intervals for search query result.
+ */
+class Interval extends CoreInterval
+{
+    /**
+     * Minimal possible value
+     */
+    const DELTA = 0.005;
+
+    /**
+     * @var ConnectionManager
+     */
+    private $connectionManager;
+
+    /**
+     * @var FieldMapperInterface
+     */
+    private $fieldMapper;
+
+    /**
+     * @var Config
+     */
+    private $clientConfig;
+
+    /**
+     * @var string
+     */
+    private $fieldName;
+
+    /**
+     * @var string
+     */
+    private $storeId;
+
+    /**
+     * @var array
+     */
+    private $entityIds;
+
+    /**
+     * @var SearchIndexNameResolver
+     */
+    private $searchIndexNameResolver;
+
+    /**
+     * @param ConnectionManager $connectionManager
+     * @param FieldMapperInterface $fieldMapper
+     * @param Config $clientConfig
+     * @param SearchIndexNameResolver $searchIndexNameResolver
+     * @param string $fieldName
+     * @param string $storeId
+     * @param array $entityIds
+     */
+    public function __construct(
+        ConnectionManager $connectionManager,
+        FieldMapperInterface $fieldMapper,
+        Config $clientConfig,
+        SearchIndexNameResolver $searchIndexNameResolver,
+        string $fieldName,
+        string $storeId,
+        array $entityIds
+    ) {
+        $this->connectionManager = $connectionManager;
+        $this->fieldMapper = $fieldMapper;
+        $this->clientConfig = $clientConfig;
+        $this->fieldName = $fieldName;
+        $this->storeId = $storeId;
+        $this->entityIds = $entityIds;
+        $this->searchIndexNameResolver = $searchIndexNameResolver;
+
+        parent::__construct(
+            $connectionManager,
+            $fieldMapper,
+            $clientConfig,
+            $searchIndexNameResolver,
+            $fieldName,
+            $storeId,
+            $entityIds,
+
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function load($limit, $offset = null, $lower = null, $upper = null)
+    {
+
+        $from = ['gte' => 0];
+        $to = ['lt' => 0];
+
+        if ($lower) {
+            $from = ['gte' => $lower - self::DELTA];
+        }
+
+        if ($upper) {
+            $to = ['lt' => $upper - self::DELTA];
+        }
+
+        $requestQuery = $this->prepareBaseRequestQuery($from, $to);
+        $requestQuery = array_merge_recursive(
+            $requestQuery,
+            ['body' => ['stored_fields' => [$this->fieldName], 'size' => $limit]]
+        );
+
+        if ($offset) {
+            $requestQuery['body']['from'] = $offset;
+        }
+
+        $queryResult = $this->connectionManager->getConnection()
+            ->query($requestQuery);
+
+        return $this->arrayValuesToFloat($queryResult['hits']['hits'], $this->fieldName);
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function loadPrevious($data, $index, $lower = null)
+    {
+
+        $from = ['gte' => 0];
+        $to = ['lt' => 0];
+
+        if ($lower) {
+            $from = ['gte' => $lower - self::DELTA];
+        }
+        if ($data) {
+            $to = ['lt' => $data - self::DELTA];
+        }
+
+        $requestQuery = $this->prepareBaseRequestQuery($from, $to);
+        $requestQuery = array_merge_recursive(
+            $requestQuery,
+            ['size' => 0]
+        );
+
+        $queryResult = $this->connectionManager->getConnection()
+            ->query($requestQuery);
+
+        $offset = $queryResult['hits']['total'];
+        if (!$offset) {
+            return false;
+        }
+
+        if (is_array($offset)) {
+            $offset = $offset['value'];
+        }
+
+        return $this->load($index - $offset + 1, $offset - 1, $lower);
+    }
+
+    /**
+     * Conver array values to float type.
+     *
+     * @param array $hits
+     * @param string $fieldName
+     *
+     * @return float[]
+     */
+    private function arrayValuesToFloat(array $hits, string $fieldName): array
+    {
+        $returnPrices = [];
+        foreach ($hits as $hit) {
+            $returnPrices[] = (float)$hit['fields'][$fieldName][0];
+        }
+
+        return $returnPrices;
+    }
+
+
+    /**
+     * Prepare base query for search.
+     *
+     * @param array|null $from
+     * @param array|null $to
+     * @return array
+     */
+    private function prepareBaseRequestQuery($from = null, $to = null): array
+    {
+        $requestQuery = [
+            'index' => $this->searchIndexNameResolver->getIndexName($this->storeId, Fulltext::INDEXER_ID),
+            'type' => $this->clientConfig->getEntityType(),
+            'body' => [
+                'stored_fields' => [
+                    '_id',
+                ],
+                'query' => [
+                    'bool' => [
+                        'must' => [
+                            'match_all' => new \stdClass(),
+                        ],
+                        'filter' => [
+                            'bool' => [
+                                'must' => [
+                                    [
+                                        'terms' => [
+                                            '_id' => $this->entityIds,
+                                        ],
+                                    ],
+                                    [
+                                        'range' => [
+                                            $this->fieldName => array_merge($from, $to),
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'sort' => [
+                    $this->fieldName,
+                ],
+            ],
+        ];
+
+        return $requestQuery;
+    }
+
+}

--- a/src/Model/Layer/Filter/Category.php
+++ b/src/Model/Layer/Filter/Category.php
@@ -15,6 +15,7 @@ namespace ScandiPWA\CatalogGraphQl\Model\Layer\Filter;
 
 use Magento\CatalogGraphQl\DataProvider\CategoryAttributesMapper;
 use Magento\CatalogGraphQl\DataProvider\Category\Query\CategoryAttributeQuery;
+use Magento\CatalogGraphQl\DataProvider\Product\LayeredNavigation\Builder\Aggregations\Category\IncludeDirectChildrenOnly;
 use Magento\CatalogGraphQl\DataProvider\Product\LayeredNavigation\RootCategoryProvider;
 use Magento\Framework\Api\Search\AggregationInterface;
 use Magento\Framework\App\ResourceConnection;
@@ -40,6 +41,7 @@ class Category extends OriginalCategoryBuilder
      * @param RootCategoryProvider $rootCategoryProvider
      * @param ResourceConnection $resourceConnection
      * @param LayerFormatter $layerFormatter
+     * @param IncludeDirectChildrenOnly $includeDirectChildrenOnly
      */
     public function __construct(
         CategoryAttributeQuery $categoryAttributeQuery,
@@ -47,6 +49,7 @@ class Category extends OriginalCategoryBuilder
         RootCategoryProvider $rootCategoryProvider,
         ResourceConnection $resourceConnection,
         LayerFormatter $layerFormatter,
+        IncludeDirectChildrenOnly $includeDirectChildrenOnly,
         AttributeDataProvider $attributeDataProvider
     ) {
         parent::__construct(
@@ -54,7 +57,8 @@ class Category extends OriginalCategoryBuilder
           $attributesMapper,
           $rootCategoryProvider,
           $resourceConnection,
-          $layerFormatter
+          $layerFormatter,
+          $includeDirectChildrenOnly
         );
 
         $this->attributeDataProvider = $attributeDataProvider;

--- a/src/Model/Resolver/Category/SortFields.php
+++ b/src/Model/Resolver/Category/SortFields.php
@@ -115,7 +115,7 @@ class SortFields implements ResolverInterface
     private function getSortOptionsByCategory(int $categoryId): array {
         $result = [];
         $category = $this->categoryRepository->get($categoryId);
-        $sortBy = $category->getAvailableSortBy();
+        $sortBy = $category->getAvailableSortBy() ?? [];
 
         foreach ($sortBy as $sortItem) {
             $result[] = [

--- a/src/SearchAdapter/Query/Builder/MatchQuery.php
+++ b/src/SearchAdapter/Query/Builder/MatchQuery.php
@@ -15,13 +15,13 @@ use Magento\Elasticsearch\Model\Adapter\FieldMapper\Product\FieldProvider\FieldT
 use Magento\Elasticsearch\Model\Config;
 use Magento\Elasticsearch\SearchAdapter\Query\ValueTransformerPool;
 use Magento\Elasticsearch\Model\Adapter\FieldMapperInterface;
-use Magento\Elasticsearch\SearchAdapter\Query\Builder\Match as CoreMatch;
+use Magento\Elasticsearch\SearchAdapter\Query\Builder\MatchQuery as CoreMatch;
 
 /**
- * Class Match
+ * Class MatchQuery
  * @package ScandiPWA\CatalogGraphQl\SearchAdapter\Query\Builder
  */
-class Match extends CoreMatch
+class MatchQuery extends CoreMatch
 {
     /**
      * Define fuzziness level of search query

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -65,8 +65,8 @@
     <preference for="Magento\GroupedProductGraphQl\Model\Resolver\GroupedItems"
                 type="ScandiPWA\CatalogGraphQl\Model\Resolver\GroupedItems" />
 
-    <preference for="Magento\Elasticsearch\SearchAdapter\Query\Builder\Match"
-                type="ScandiPWA\CatalogGraphQl\SearchAdapter\Query\Builder\Match"/>
+    <preference for="Magento\Elasticsearch\SearchAdapter\Query\Builder\MatchQuery"
+                type="ScandiPWA\CatalogGraphQl\SearchAdapter\Query\Builder\MatchQuery"/>
 
     <type name="Magento\Framework\GraphQl\Query\QueryComplexityLimiter">
         <arguments>

--- a/src/etc/di.xml
+++ b/src/etc/di.xml
@@ -105,4 +105,6 @@
         <plugin name="aggregation_equalize_products_count_handler"
                 type="ScandiPWA\CatalogGraphQl\Plugin\SearchAdapter\Aggregation\BuilderPlugin" />
     </type>
+    <preference for="Magento\Elasticsearch\Elasticsearch5\SearchAdapter\Aggregation\Interval"
+                type="ScandiPWA\CatalogGraphQl\Elasticsearch5\SearchAdapter\Aggregation\Interval" />
 </config>


### PR DESCRIPTION
Fixes scandipwa/scandipwa#4122

Got error in `localmodules/catalog-graphql/src/Model/Layer/Filter/Category.php` that in parent::__construct only 5 params were passed and in newer version it needs 6 params

- Passed the 6th param `$includeDirectChildrenOnly `class.

- Now I can get the product filters but I'm getting sort_fields as null and error for that issue

**Note**

- In my local the ` "scandipwa/performance": "^1.1.0",` in require block in composer.json  was changed to `"scandipwa/performance": "dev-master as 1.5.5",`